### PR TITLE
fix: support Arch Linux Wails builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,11 @@ Production build:
 # Windows PowerShell
 .\build.ps1
 
-# macOS / Linux
-./build.sh
+# Linux
+bash build/build-wails.sh linux
+
+# Arch Linux / WebKitGTK 4.1
+wails build -tags webkit2_41 -ldflags "-s -w" -trimpath
 ```
 
 Detailed build instructions: [docs/BUILD.md](docs/BUILD.md)
@@ -241,8 +244,9 @@ wails dev
 Compilación:
 
 ```bash
-.\build.ps1   # Windows
-./build.sh    # macOS / Linux
+.\build.ps1                 # Windows
+bash build/build-wails.sh linux # Linux
+wails build -tags webkit2_41    # Arch Linux / WebKitGTK 4.1
 ```
 
 Guía completa: [docs/BUILD.md](docs/BUILD.md)
@@ -319,8 +323,9 @@ wails dev
 Build:
 
 ```bash
-.\build.ps1   # Windows
-./build.sh    # macOS / Linux
+.\build.ps1                 # Windows
+bash build/build-wails.sh linux # Linux
+wails build -tags webkit2_41    # Arch Linux / WebKitGTK 4.1
 ```
 
 Istruzioni complete: [docs/BUILD.md](docs/BUILD.md)

--- a/build/build-wails.sh
+++ b/build/build-wails.sh
@@ -77,20 +77,50 @@ fi
 build_platform() {
     local PLATFORM="$1"     # e.g. windows/amd64
     local OUTPUT="$2"       # e.g. dist/adomnia-windows-amd64.exe
+    local TAGS="${3:-}"
     local LDFLAGS="-s -w -X main.Version=${VERSION} -X main.GitCommit=${GIT_COMMIT}"
+    local OUTNAME
+    local BUILT_OUTPUT
+    local TAG_ARGS=()
+
+    OUTNAME="$(basename "$OUTPUT")"
+    BUILT_OUTPUT="build/bin/$OUTNAME"
+
+    if [ -n "$TAGS" ]; then
+        TAG_ARGS=(-tags "$TAGS")
+    fi
 
     echo -e "${YELLOW}→${NC} Building $PLATFORM..."
     "$WAILS_BIN" build \
         -platform "$PLATFORM" \
+        "${TAG_ARGS[@]}" \
         -ldflags "$LDFLAGS" \
-        -o "$(pwd)/$OUTPUT" 2>&1 | grep -v "^[[:space:]]*$" || true
+        -o "$OUTNAME" 2>&1 | grep -v "^[[:space:]]*$" || true
+
+    if [ -f "$BUILT_OUTPUT" ]; then
+        mkdir -p "$(dirname "$OUTPUT")"
+        cp "$BUILT_OUTPUT" "$OUTPUT"
+    fi
 
     if [ -f "$OUTPUT" ]; then
+        chmod +x "$OUTPUT" 2>/dev/null || true
         SIZE=$(ls -lh "$OUTPUT" | awk '{print $5}')
         echo -e "${GREEN}✓${NC} $OUTPUT ($SIZE)"
     else
         echo -e "${RED}✗${NC} Build failed for $PLATFORM"
         return 1
+    fi
+}
+
+detect_linux_webkit_tags() {
+    if [ "$(uname -s)" != "Linux" ]; then
+        return
+    fi
+
+    if command -v pkg-config &>/dev/null &&
+        pkg-config --exists webkit2gtk-4.1 &&
+        ! pkg-config --exists webkit2gtk-4.0; then
+        echo "webkit2_41"
     fi
 }
 
@@ -135,10 +165,17 @@ build_linux() {
     echo -e "${CYAN}🐧  Linux${NC}"
     if [ "$(uname -s)" != "Linux" ]; then
         echo -e "${YELLOW}⚠️  Linux Wails builds require a Linux host (WebKitGTK CGO dependency)${NC}"
-        echo "   Use the Dockerfile: docker build -f build/Dockerfile -t adomnia-build ."
+        echo "   Use the Dockerfile: docker build -f Dockerfile.linux -t adomnia-build ."
         return 1
     fi
-    build_platform "linux/amd64" "$OUT_DIR/adomnia-linux-amd64"
+
+    local TAGS
+    TAGS="$(detect_linux_webkit_tags)"
+    if [ -n "$TAGS" ]; then
+        echo -e "${GREEN}✓${NC} WebKitGTK 4.1 detected; using Go build tags: $TAGS"
+    fi
+
+    build_platform "linux/amd64" "$OUT_DIR/adomnia-linux-amd64" "$TAGS"
 }
 
 create_checksums() {

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -56,9 +56,13 @@ This guide covers building adOmnia for all supported platforms: Windows, macOS, 
   sudo dnf install gtk3-devel webkit2gtk4.0-devel \
     libayatana-appindicator-gtk3-devel librsvg2-devel
 
-  # Arch
-  sudo pacman -S gtk3 webkit2gtk libayatana-appindicator librsvg
+  # Arch Linux
+  sudo pacman -S --needed base-devel git go nodejs npm pkgconf \
+    gtk3 webkit2gtk-4.1 libayatana-appindicator librsvg
   ```
+
+  Arch Linux provides WebKitGTK through `webkit2gtk-4.1`; use `-tags webkit2_41`
+  when running `wails dev`, `wails build`, or `go test`.
 
 ---
 
@@ -77,13 +81,16 @@ wails dev
 
 # Build production binary (stripped, no debug info)
 wails build -ldflags "-s -w" -trimpath
+
+# Arch Linux / WebKitGTK 4.1
+wails build -tags webkit2_41 -ldflags "-s -w" -trimpath
 ```
 
 ### One-command build scripts (include ldflags automatically)
 
 ```bash
-# macOS / Linux
-./build.sh
+# Linux
+bash build/build-wails.sh linux
 
 # Windows (PowerShell)
 .\build.ps1


### PR DESCRIPTION
## Summary
  - Add WebKitGTK 4.1 detection to the Wails build script and pass `webkit2_41` when needed
  - Document Arch Linux build dependencies and the required Wails build tag
  - Update README build commands to use the existing Wails build script

  ## Verification
  - `bash -n build/build-wails.sh`
  - `wails build -platform linux/amd64 -tags webkit2_41 -dryrun -ldflags "-s -w" -trimpath`