### PR TITLE
Fix Linux dark theme control styling in Wails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -306,6 +306,7 @@ go test ./...
 - **Coerenza dimensionale:** stessi spacing, stesse dimensioni font, stessi pattern di interazione
 - **Feedback visivo immediato:** ogni azione deve avere un feedback percepibile (hover, active, loading, success, error)
 - **Niente UI "cheap":** no bordi storti, no colori fuori palette, no spaziature inconsistenti
+- **Coerenza cross-platform Wails/WebKitGTK:** tratta ogni differenza WebKitGTK visibile nella UI Linux come un problema di qualita' prodotto, non come un dettaglio tecnico secondario. Preferisci normalizzazioni globali token-based per problemi ricorrenti in `frontend/src/styles/globals.css`; usa workaround locali solo quando il componente e' davvero isolato. In particolare, Linux puo' renderizzare controlli nativi chiari dentro temi scuri: per `select`, `input`, `textarea`, checkbox/radio e number input mantieni `color-scheme`, le normalizzazioni globali, token `surface/text/border/accent/status`, ed evita colori Tailwind hardcoded nella UI primaria (`bg-white/*`, `text-purple-*`, `bg-green-*`, ecc.) salvo stati semantici intenzionali.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,6 +335,7 @@ if (request.auth.type === 'aws4') {
 - **Dimensional consistency:** same spacing, same font sizes, same interaction patterns
 - **Immediate visual feedback:** every action needs perceptible feedback (hover, active, loading, success, error)
 - **No "cheap" UI:** no misaligned borders, no off-palette colors, no inconsistent spacing
+- **Wails/WebKitGTK cross-platform cohesion:** treat every user-visible WebKitGTK rendering difference on Linux as a product-quality issue, not as a secondary technical detail. Prefer global token-based normalization for recurring issues in `frontend/src/styles/globals.css`; use local workarounds only when the affected component is truly isolated. In particular, Linux can render native form controls with a light system appearance inside dark themes: for `select`, `input`, `textarea`, checkbox/radio, and number inputs, keep `color-scheme`, rely on the global normalizations, use `surface/text/border/accent/status` tokens, and avoid hardcoded Tailwind palette colors in primary UI (`bg-white/*`, `text-purple-*`, `bg-green-*`, etc.) unless they are intentional semantic states.
 
 ---
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import { importCollectionsFromText } from '@/lib/collectionTransfer'
 import { migrateCollections } from '@/stores/collections'
 import { getUIFontStack } from '@/lib/uiFonts'
 import { GetStartupWindowChrome } from '@/wailsjs/go/main/App'
+import { UploadCloud } from 'lucide-react'
 
 type WindowChromeMode = 'app' | 'app-xwayland' | 'system'
 import { loadDefaultPostmanDemo } from '@/lib/demoWorkspace'
@@ -36,16 +37,16 @@ class ErrorBoundary extends Component<{ children: ReactNode }, { error: Error | 
   render() {
     if (this.state.error) {
       return (
-        <div style={{ padding: 32, color: '#f87171', fontFamily: 'monospace', background: '#0f0f0f', minHeight: '100vh' }}>
-          <h2 style={{ marginBottom: 12, fontSize: 16 }}>Something went wrong</h2>
-          <p style={{ fontSize: 12, lineHeight: 1.5, color: '#d1d5db', maxWidth: 560 }}>
+        <div className="min-h-screen bg-surface-0 p-8 font-mono text-error">
+          <h2 className="mb-3 text-base font-semibold">Something went wrong</h2>
+          <p className="max-w-xl text-xs leading-5 text-text-2">
             adOmnia hit a recoverable UI error. Your local data was not sent anywhere.
             Try recovering this view, or reload the app if the problem keeps happening.
           </p>
-          <pre style={{ fontSize: 12, whiteSpace: 'pre-wrap', opacity: 0.8, marginTop: 12 }}>{this.state.error.message}</pre>
+          <pre className="mt-3 whitespace-pre-wrap text-xs text-error/80">{this.state.error.message}</pre>
           <button
             onClick={() => this.setState({ error: null })}
-            style={{ marginTop: 20, padding: '6px 16px', background: '#6366f1', color: '#fff', border: 'none', borderRadius: 6, cursor: 'pointer', fontSize: 13 }}
+            className="mt-5 h-8 rounded-md bg-accent px-4 text-xs font-medium text-white transition-colors hover:bg-accent-hover"
           >
             Try to recover
           </button>
@@ -369,12 +370,8 @@ function App() {
           {/* Drop overlay */}
           {dragOver && (
             <div className="absolute inset-0 z-[9999] flex items-center justify-center bg-black/60 backdrop-blur-sm pointer-events-none">
-              <div className="flex flex-col items-center gap-3 p-8 bg-surface-1 border-2 border-dashed border-accent rounded-2xl shadow-2xl">
-                <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="text-accent">
-                  <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4" strokeLinecap="round" strokeLinejoin="round"/>
-                  <polyline points="7 10 12 15 17 10" strokeLinecap="round" strokeLinejoin="round"/>
-                  <line x1="12" y1="15" x2="12" y2="3" strokeLinecap="round" strokeLinejoin="round"/>
-                </svg>
+              <div className="flex flex-col items-center gap-3 rounded-lg border-2 border-dashed border-accent bg-surface-1 p-8 shadow-2xl">
+                <UploadCloud size={48} strokeWidth={1.5} className="text-accent" />
                 <p className="text-sm font-semibold text-text-1">Drop to import collection</p>
                 <p className="text-[10px] text-text-3">Postman, Insomnia, Bruno, OpenAPI, adOmnia</p>
               </div>
@@ -383,7 +380,7 @@ function App() {
 
           {/* Import feedback toast */}
           {dropFeedback && (
-            <div className={`absolute bottom-16 left-1/2 -translate-x-1/2 z-[9999] px-4 py-2 rounded-lg shadow-xl text-xs font-medium transition-all ${dropFeedback.ok ? 'bg-green-600/90 text-white' : 'bg-red-600/90 text-white'}`}>
+            <div className={`absolute bottom-16 left-1/2 z-[9999] -translate-x-1/2 rounded-md border px-4 py-2 text-xs font-medium shadow-xl transition-all ${dropFeedback.ok ? 'border-success/30 bg-success/15 text-success' : 'border-error/30 bg-error/15 text-error'}`}>
               {dropFeedback.msg}
             </div>
           )}

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -4,6 +4,8 @@
 
 @layer base {
   :root {
+    color-scheme: dark;
+
     /* Surface / backgrounds */
     --color-surface-0: #05070D;
     --color-surface-1: #0B0D14;
@@ -79,6 +81,8 @@
 
   /* Light theme overrides */
   .light {
+    color-scheme: light;
+
     --color-surface-0: #F8FAFC;
     --color-surface-1: #F1F5F9;
     --color-surface-2: #E2E8F0;
@@ -123,11 +127,80 @@
     border-color: var(--color-border-1);
   }
 
+  html.dark {
+    color-scheme: dark;
+  }
+
+  html.light {
+    color-scheme: light;
+  }
+
   body {
     font-family: var(--font-ui, var(--font-sans));
     font-size: 13px;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+  }
+
+  button,
+  input,
+  select,
+  textarea {
+    font: inherit;
+  }
+
+  input,
+  select,
+  textarea {
+    background-color: var(--color-surface-2);
+    color: var(--color-text-1);
+  }
+
+  input::placeholder,
+  textarea::placeholder {
+    color: var(--color-text-4);
+  }
+
+  select {
+    appearance: none;
+    -webkit-appearance: none;
+    background-image:
+      linear-gradient(45deg, transparent 50%, var(--color-text-2) 50%),
+      linear-gradient(135deg, var(--color-text-2) 50%, transparent 50%);
+    background-position:
+      calc(100% - 14px) calc(50% - 2px),
+      calc(100% - 9px) calc(50% - 2px);
+    background-repeat: no-repeat;
+    background-size: 5px 5px, 5px 5px;
+    padding-right: 28px;
+  }
+
+  select option {
+    background-color: var(--color-surface-2);
+    color: var(--color-text-1);
+  }
+
+  input[type='checkbox'],
+  input[type='radio'] {
+    accent-color: var(--color-accent);
+  }
+
+  input[type='number'] {
+    appearance: textfield;
+    -moz-appearance: textfield;
+  }
+
+  input[type='number']::-webkit-inner-spin-button,
+  input[type='number']::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
+  button:disabled,
+  input:disabled,
+  select:disabled,
+  textarea:disabled {
+    cursor: not-allowed;
   }
 
   ::-webkit-scrollbar {


### PR DESCRIPTION
## Summary

  Fixes Linux/Wails dark-theme inconsistencies caused by WebKitGTK native form rendering.

  This PR:
  - Adds global dark/light `color-scheme` handling.
  - Normalizes `select`, `input`, `textarea`, checkbox/radio, and number inputs through `frontend/src/styles/globals.css`.
  - Replaces hardcoded inline styling in the app error boundary with design tokens.
  - Aligns drag/drop import overlay and toast feedback with the app token system.
  - Documents Wails/WebKitGTK visual-cohesion rules in `AGENTS.md` and `CLAUDE.md`.

  ## Product Impact

  Improves visual consistency on Linux, especially in dark theme, where native controls could render with a light system appearance and
  become unreadable.

  The Settings Appearance panel and other form-heavy panels should now keep coherent dark styling across platforms.

  ## Type

  - [x] Bug fix
  - [ ] Feature
  - [x] UI/UX polish
  - [x] Documentation
  - [ ] Build/release
  - [ ] Refactor
  - [ ] Security/privacy

  ## Verification

  - [x] `cd frontend && npm run build`
  - [ ] `go test ./...`
  - [ ] Manual smoke test performed
  - [ ] Not applicable

  Manual test notes:

  Frontend production build completed successfully. Manual Linux/Wails visual smoke test is recommended before merge.

  ## Risk

  - [ ] Low: isolated change
  - [x] Medium: shared UI/state/build behavior
  - [ ] High: storage, workspace format, security, release pipeline, or network behavior

  ## Checklist

  - [x] The change preserves local-first behavior.
  - [x] User-facing behavior is documented.
  - [ ] Screenshots are included for visible UI changes.
  - [ ] `CHANGELOG.md` is updated under `[Unreleased]` if release-worthy.
  - [x] Secrets, tokens, cookies, and private URLs are not included in logs/screenshots.

