### PR TITLE
Improve browser debugger sources and DOM inspection

### DIFF
--- a/browser_debug.go
+++ b/browser_debug.go
@@ -163,8 +163,11 @@ func (b *BrowserDebug) Connect() error {
 		b.Disconnect()
 		return fmt.Errorf("failed to enable Network domain: %w", err)
 	}
+	if err := b.disableBrowserCache(); err != nil {
+		log.Printf("[debug] warning: failed to disable browser cache: %v", err)
+	}
 
-	log.Printf("[debug] CDP connected and Network domain enabled")
+	log.Printf("[debug] CDP connected, Network domain enabled, cache disabled")
 	return nil
 }
 
@@ -434,7 +437,7 @@ func (b *BrowserDebug) handleEvent(msg cdpMessage) {
 		b.handleLoadingFinished(msg.Params)
 	case "Runtime.consoleAPICalled":
 		b.HandleConsoleEvent(msg.Params)
-	case "Debugger.paused", "Debugger.resumed":
+	case "Debugger.paused", "Debugger.resumed", "Debugger.scriptParsed":
 		b.HandleDebuggerEvent(msg.Method, msg.Params)
 	}
 }
@@ -587,7 +590,7 @@ func (b *BrowserDebug) discoverDebugTarget() (string, error) {
 		}
 
 		var targets []struct {
-			Type                string `json:"type"`
+			Type                 string `json:"type"`
 			WebSocketDebuggerURL string `json:"webSocketDebuggerUrl"`
 		}
 		if err := json.Unmarshal(body, &targets); err != nil {

--- a/browser_debug_discover.go
+++ b/browser_debug_discover.go
@@ -133,8 +133,11 @@ func (b *BrowserDebug) ConnectToTarget(wsURL string) error {
 	if err := b.sendCommand("Network.enable", nil); err != nil {
 		log.Printf("[debug] warning: failed to enable Network domain: %v", err)
 	}
+	if err := b.disableBrowserCache(); err != nil {
+		log.Printf("[debug] warning: failed to disable browser cache: %v", err)
+	}
 
-	log.Printf("[debug] connected to target, Network domain enabled")
+	log.Printf("[debug] connected to target, Network domain enabled, cache disabled")
 	return nil
 }
 

--- a/browser_debug_extended.go
+++ b/browser_debug_extended.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -48,9 +50,9 @@ func (b *BrowserDebug) EvalJS(expression string) (ConsoleEntry, error) {
 
 	var resp struct {
 		Result struct {
-			Type  string          `json:"type"`
-			Value json.RawMessage `json:"value"`
-			Description string   `json:"description"`
+			Type        string          `json:"type"`
+			Value       json.RawMessage `json:"value"`
+			Description string          `json:"description"`
 		} `json:"result"`
 		ExceptionDetails *struct {
 			Text      string `json:"text"`
@@ -178,6 +180,7 @@ func (b *BrowserDebug) HandleConsoleEvent(params map[string]interface{}) {
 type BreakpointInfo struct {
 	ID           string `json:"id"`
 	ScriptURL    string `json:"scriptUrl"`
+	ScriptID     string `json:"scriptId,omitempty"`
 	LineNumber   int    `json:"lineNumber"`
 	ColumnNumber int    `json:"columnNumber"`
 	Condition    string `json:"condition,omitempty"`
@@ -189,6 +192,7 @@ type PausedState struct {
 	Reason     string      `json:"reason"`
 	CallFrames []CallFrame `json:"callFrames"`
 	ScriptURL  string      `json:"scriptUrl"`
+	ScriptID   string      `json:"scriptId"`
 	LineNumber int         `json:"lineNumber"`
 }
 
@@ -197,8 +201,33 @@ type CallFrame struct {
 	ID           string `json:"id"`
 	FunctionName string `json:"functionName"`
 	URL          string `json:"url"`
+	ScriptID     string `json:"scriptId"`
 	LineNumber   int    `json:"lineNumber"`
 	ColumnNumber int    `json:"columnNumber"`
+}
+
+// ScriptInfo represents a JavaScript source known by the Debugger domain.
+type ScriptInfo struct {
+	ScriptID           string `json:"scriptId"`
+	URL                string `json:"url"`
+	StartLine          int    `json:"startLine"`
+	EndLine            int    `json:"endLine"`
+	ExecutionContextID int    `json:"executionContextId"`
+	Hash               string `json:"hash"`
+}
+
+// SourceFileInfo represents a source/resource visible in the debugger source view.
+type SourceFileInfo struct {
+	ID               string `json:"id"`
+	URL              string `json:"url"`
+	Type             string `json:"type"`
+	MimeType         string `json:"mimeType"`
+	ScriptID         string `json:"scriptId,omitempty"`
+	FrameID          string `json:"frameId,omitempty"`
+	StartLine        int    `json:"startLine"`
+	EndLine          int    `json:"endLine"`
+	CanSetBreakpoint bool   `json:"canSetBreakpoint"`
+	FromDebugger     bool   `json:"fromDebugger"`
 }
 
 var (
@@ -207,6 +236,9 @@ var (
 
 	pausedState   PausedState
 	pausedStateMu sync.RWMutex
+
+	debugScripts   map[string]ScriptInfo
+	debugScriptsMu sync.Mutex
 )
 
 // EnableDebugger enables the Debugger domain.
@@ -220,6 +252,9 @@ func (b *BrowserDebug) EnableDebugger() error {
 
 	if err := b.sendCommand("Debugger.enable", nil); err != nil {
 		return fmt.Errorf("failed to enable Debugger domain: %w", err)
+	}
+	if err := b.disableBrowserCache(); err != nil {
+		log.Printf("[debug] warning: failed to disable browser cache: %v", err)
 	}
 
 	log.Printf("[debug] Debugger domain enabled")
@@ -286,12 +321,13 @@ func (b *BrowserDebug) SetBreakpoint(url string, line int, condition string) (st
 	}
 
 	info := BreakpointInfo{
-		ID:        resp.BreakpointID,
-		ScriptURL: url,
+		ID:         resp.BreakpointID,
+		ScriptURL:  url,
 		LineNumber: line,
-		Condition: condition,
+		Condition:  condition,
 	}
 	if len(resp.Locations) > 0 {
+		info.ScriptID = resp.Locations[0].ScriptID
 		info.LineNumber = resp.Locations[0].LineNumber
 		info.ColumnNumber = resp.Locations[0].ColumnNumber
 	}
@@ -301,6 +337,82 @@ func (b *BrowserDebug) SetBreakpoint(url string, line int, condition string) (st
 	debugBreakpointsMu.Unlock()
 
 	log.Printf("[debug] breakpoint set: id=%s url=%s line=%d", resp.BreakpointID, url, line)
+	return resp.BreakpointID, nil
+}
+
+// SetBreakpointByScriptID sets a breakpoint directly in a parsed script.
+func (b *BrowserDebug) SetBreakpointByScriptID(scriptId string, line int, column int, condition string) (string, error) {
+	b.mu.Lock()
+	if !b.connected {
+		b.mu.Unlock()
+		return "", fmt.Errorf("not connected to CDP")
+	}
+	b.mu.Unlock()
+
+	if strings.TrimSpace(scriptId) == "" {
+		return "", fmt.Errorf("script id is required")
+	}
+	if line < 0 {
+		return "", fmt.Errorf("line must be greater than or equal to zero")
+	}
+	if column < 0 {
+		column = 0
+	}
+
+	params := map[string]interface{}{
+		"location": map[string]interface{}{
+			"scriptId":     scriptId,
+			"lineNumber":   line,
+			"columnNumber": column,
+		},
+	}
+	if condition != "" {
+		params["condition"] = condition
+	}
+
+	result, err := b.sendCommandWithResult("Debugger.setBreakpoint", params)
+	if err != nil {
+		return "", fmt.Errorf("failed to set script breakpoint: %w", err)
+	}
+
+	var resp struct {
+		BreakpointID   string `json:"breakpointId"`
+		ActualLocation struct {
+			ScriptID     string `json:"scriptId"`
+			LineNumber   int    `json:"lineNumber"`
+			ColumnNumber int    `json:"columnNumber"`
+		} `json:"actualLocation"`
+	}
+	if err := json.Unmarshal(result, &resp); err != nil {
+		return "", fmt.Errorf("failed to parse breakpoint response: %w", err)
+	}
+
+	scriptURL := ""
+	debugScriptsMu.Lock()
+	if script, ok := debugScripts[scriptId]; ok {
+		scriptURL = script.URL
+	}
+	debugScriptsMu.Unlock()
+
+	info := BreakpointInfo{
+		ID:           resp.BreakpointID,
+		ScriptID:     scriptId,
+		ScriptURL:    scriptURL,
+		LineNumber:   line,
+		ColumnNumber: column,
+		Condition:    condition,
+	}
+	if resp.ActualLocation.ScriptID != "" {
+		info.ScriptID = resp.ActualLocation.ScriptID
+		info.LineNumber = resp.ActualLocation.LineNumber
+		info.ColumnNumber = resp.ActualLocation.ColumnNumber
+	}
+
+	debugBreakpointsMu.Lock()
+	debugBreakpoints = append(debugBreakpoints, info)
+	debugBreakpointsMu.Unlock()
+
+	log.Printf("[debug] script breakpoint set: id=%s scriptId=%s line=%d", resp.BreakpointID, scriptId, line)
 	return resp.BreakpointID, nil
 }
 
@@ -339,6 +451,251 @@ func (b *BrowserDebug) GetBreakpoints() []BreakpointInfo {
 	result := make([]BreakpointInfo, len(debugBreakpoints))
 	copy(result, debugBreakpoints)
 	return result
+}
+
+// GetScripts returns the JavaScript sources seen by the Debugger domain.
+func (b *BrowserDebug) GetScripts() []ScriptInfo {
+	debugScriptsMu.Lock()
+	defer debugScriptsMu.Unlock()
+
+	result := make([]ScriptInfo, 0, len(debugScripts))
+	for _, script := range debugScripts {
+		result = append(result, script)
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		leftURL := result[i].URL
+		rightURL := result[j].URL
+		if leftURL == "" {
+			leftURL = "inline:" + result[i].ScriptID
+		}
+		if rightURL == "" {
+			rightURL = "inline:" + result[j].ScriptID
+		}
+		if leftURL == rightURL {
+			return result[i].ScriptID < result[j].ScriptID
+		}
+		return leftURL < rightURL
+	})
+
+	return result
+}
+
+// GetScriptSource returns the source text for a Debugger scriptId.
+func (b *BrowserDebug) GetScriptSource(scriptId string) (string, error) {
+	b.mu.Lock()
+	if !b.connected {
+		b.mu.Unlock()
+		return "", fmt.Errorf("not connected to CDP")
+	}
+	b.mu.Unlock()
+
+	if strings.TrimSpace(scriptId) == "" {
+		return "", fmt.Errorf("script id is required")
+	}
+
+	result, err := b.sendCommandWithResult("Debugger.getScriptSource", map[string]interface{}{
+		"scriptId": scriptId,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to get script source: %w", err)
+	}
+
+	var resp struct {
+		ScriptSource string `json:"scriptSource"`
+		Bytecode     string `json:"bytecode"`
+	}
+	if err := json.Unmarshal(result, &resp); err != nil {
+		return "", fmt.Errorf("failed to parse script source response: %w", err)
+	}
+	if resp.ScriptSource == "" && resp.Bytecode != "" {
+		return "[compiled bytecode source is not available]", nil
+	}
+	return resp.ScriptSource, nil
+}
+
+// GetSourceFiles returns debugger scripts merged with the page resource tree.
+func (b *BrowserDebug) GetSourceFiles() ([]SourceFileInfo, error) {
+	b.mu.Lock()
+	if !b.connected {
+		b.mu.Unlock()
+		return nil, fmt.Errorf("not connected to CDP")
+	}
+	b.mu.Unlock()
+
+	if err := b.disableBrowserCache(); err != nil {
+		return nil, err
+	}
+	_ = b.sendCommand("Page.enable", nil)
+
+	scripts := b.GetScripts()
+	filesByID := make(map[string]SourceFileInfo)
+	resourceByURL := make(map[string]string)
+
+	result, err := b.sendCommandWithResult("Page.getResourceTree", nil)
+	if err == nil {
+		var resp struct {
+			FrameTree pageFrameTree `json:"frameTree"`
+		}
+		if err := json.Unmarshal(result, &resp); err == nil {
+			collectPageResources(resp.FrameTree, filesByID, resourceByURL)
+		}
+	}
+
+	for _, script := range scripts {
+		id := "script:" + script.ScriptID
+		file := SourceFileInfo{
+			ID:               id,
+			URL:              script.URL,
+			Type:             "Script",
+			MimeType:         "text/javascript",
+			ScriptID:         script.ScriptID,
+			StartLine:        script.StartLine,
+			EndLine:          script.EndLine,
+			CanSetBreakpoint: true,
+			FromDebugger:     true,
+		}
+		if script.URL != "" {
+			if resourceID, ok := resourceByURL[script.URL]; ok {
+				resource := filesByID[resourceID]
+				file.Type = resource.Type
+				if file.Type == "" {
+					file.Type = "Script"
+				}
+				if resource.MimeType != "" {
+					file.MimeType = resource.MimeType
+				}
+				file.FrameID = resource.FrameID
+				delete(filesByID, resourceID)
+			}
+		}
+		filesByID[file.ID] = file
+	}
+
+	files := make([]SourceFileInfo, 0, len(filesByID))
+	for _, file := range filesByID {
+		files = append(files, file)
+	}
+
+	sort.Slice(files, func(i, j int) bool {
+		leftRank := sourceTypeRank(files[i].Type)
+		rightRank := sourceTypeRank(files[j].Type)
+		if leftRank != rightRank {
+			return leftRank < rightRank
+		}
+		left := files[i].URL
+		right := files[j].URL
+		if left == "" {
+			left = files[i].ID
+		}
+		if right == "" {
+			right = files[j].ID
+		}
+		return left < right
+	})
+
+	return files, nil
+}
+
+// GetSourceFileContent returns source/resource text for a source file ID from GetSourceFiles.
+func (b *BrowserDebug) GetSourceFileContent(sourceId string) (string, error) {
+	b.mu.Lock()
+	if !b.connected {
+		b.mu.Unlock()
+		return "", fmt.Errorf("not connected to CDP")
+	}
+	b.mu.Unlock()
+
+	if err := b.disableBrowserCache(); err != nil {
+		return "", err
+	}
+
+	if strings.HasPrefix(sourceId, "script:") {
+		return b.GetScriptSource(strings.TrimPrefix(sourceId, "script:"))
+	}
+
+	if !strings.HasPrefix(sourceId, "resource:") {
+		return "", fmt.Errorf("unknown source id: %s", sourceId)
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(sourceId, "resource:"))
+	if err != nil {
+		return "", fmt.Errorf("invalid resource id: %w", err)
+	}
+	parts := strings.SplitN(string(payload), "\n", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", fmt.Errorf("invalid resource id payload")
+	}
+
+	result, err := b.sendCommandWithResult("Page.getResourceContent", map[string]interface{}{
+		"frameId": parts[0],
+		"url":     parts[1],
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to get resource content: %w", err)
+	}
+
+	var resp struct {
+		Content       string `json:"content"`
+		Base64Encoded bool   `json:"base64Encoded"`
+	}
+	if err := json.Unmarshal(result, &resp); err != nil {
+		return "", fmt.Errorf("failed to parse resource content response: %w", err)
+	}
+	if resp.Base64Encoded {
+		return "[binary resource content is not displayed in the source viewer]", nil
+	}
+	return resp.Content, nil
+}
+
+// ReloadPageNoCache clears collected source metadata and reloads the current page without cache.
+func (b *BrowserDebug) ReloadPageNoCache() error {
+	b.mu.Lock()
+	if !b.connected {
+		b.mu.Unlock()
+		return fmt.Errorf("not connected to CDP")
+	}
+	b.mu.Unlock()
+
+	if err := b.disableBrowserCache(); err != nil {
+		return err
+	}
+
+	clearDebuggerSources()
+
+	if err := b.sendCommand("Page.enable", nil); err != nil {
+		return fmt.Errorf("failed to enable Page domain: %w", err)
+	}
+	if err := b.sendCommand("Page.reload", map[string]interface{}{
+		"ignoreCache": true,
+	}); err != nil {
+		return fmt.Errorf("failed to reload page without cache: %w", err)
+	}
+
+	pausedStateMu.Lock()
+	pausedState = PausedState{Paused: false}
+	pausedStateMu.Unlock()
+
+	log.Printf("[debug] page reloaded with cache disabled")
+	return nil
+}
+
+func (b *BrowserDebug) disableBrowserCache() error {
+	if err := b.sendCommand("Network.enable", nil); err != nil {
+		return fmt.Errorf("failed to enable Network domain: %w", err)
+	}
+	if err := b.sendCommand("Network.setCacheDisabled", map[string]interface{}{
+		"cacheDisabled": true,
+	}); err != nil {
+		return fmt.Errorf("failed to disable browser cache: %w", err)
+	}
+	return nil
+}
+
+func clearDebuggerSources() {
+	debugScriptsMu.Lock()
+	debugScripts = make(map[string]ScriptInfo)
+	debugScriptsMu.Unlock()
 }
 
 // Resume resumes execution after a breakpoint pause.
@@ -417,6 +774,28 @@ func (b *BrowserDebug) GetPausedState() PausedState {
 // msg.Method starts with "Debugger.".
 func (b *BrowserDebug) HandleDebuggerEvent(method string, params map[string]interface{}) {
 	switch method {
+	case "Debugger.scriptParsed":
+		scriptID, _ := params["scriptId"].(string)
+		if scriptID == "" {
+			return
+		}
+
+		script := ScriptInfo{
+			ScriptID:           scriptID,
+			URL:                stringFromMap(params, "url"),
+			StartLine:          intFromMap(params, "startLine"),
+			EndLine:            intFromMap(params, "endLine"),
+			ExecutionContextID: intFromMap(params, "executionContextId"),
+			Hash:               stringFromMap(params, "hash"),
+		}
+
+		debugScriptsMu.Lock()
+		if debugScripts == nil {
+			debugScripts = make(map[string]ScriptInfo)
+		}
+		debugScripts[scriptID] = script
+		debugScriptsMu.Unlock()
+
 	case "Debugger.paused":
 		reason, _ := params["reason"].(string)
 		callFramesRaw, _ := params["callFrames"].([]interface{})
@@ -432,11 +811,19 @@ func (b *BrowserDebug) HandleDebuggerEvent(method string, params map[string]inte
 				FunctionName: stringFromMap(cfMap, "functionName"),
 			}
 			if loc, ok := cfMap["location"].(map[string]interface{}); ok {
+				frame.ScriptID = stringFromMap(loc, "scriptId")
 				frame.LineNumber = intFromMap(loc, "lineNumber")
 				frame.ColumnNumber = intFromMap(loc, "columnNumber")
 			}
 			if urlVal, ok := cfMap["url"].(string); ok {
 				frame.URL = urlVal
+			}
+			if frame.URL == "" && frame.ScriptID != "" {
+				debugScriptsMu.Lock()
+				if script, ok := debugScripts[frame.ScriptID]; ok {
+					frame.URL = script.URL
+				}
+				debugScriptsMu.Unlock()
 			}
 			frames = append(frames, frame)
 		}
@@ -448,6 +835,7 @@ func (b *BrowserDebug) HandleDebuggerEvent(method string, params map[string]inte
 		}
 		if len(frames) > 0 {
 			state.ScriptURL = frames[0].URL
+			state.ScriptID = frames[0].ScriptID
 			state.LineNumber = frames[0].LineNumber
 		}
 
@@ -466,6 +854,84 @@ func (b *BrowserDebug) HandleDebuggerEvent(method string, params map[string]inte
 	}
 }
 
+type pageFrameTree struct {
+	Frame       pageFrame       `json:"frame"`
+	Resources   []pageResource  `json:"resources"`
+	ChildFrames []pageFrameTree `json:"childFrames"`
+}
+
+type pageFrame struct {
+	ID       string `json:"id"`
+	URL      string `json:"url"`
+	MimeType string `json:"mimeType"`
+}
+
+type pageResource struct {
+	URL      string  `json:"url"`
+	Type     string  `json:"type"`
+	MimeType string  `json:"mimeType"`
+	Size     float64 `json:"contentSize"`
+}
+
+func collectPageResources(tree pageFrameTree, filesByID map[string]SourceFileInfo, resourceByURL map[string]string) {
+	if tree.Frame.ID != "" && tree.Frame.URL != "" {
+		addPageResource(filesByID, resourceByURL, SourceFileInfo{
+			URL:      tree.Frame.URL,
+			Type:     "Document",
+			MimeType: tree.Frame.MimeType,
+			FrameID:  tree.Frame.ID,
+		})
+	}
+
+	for _, resource := range tree.Resources {
+		if resource.URL == "" {
+			continue
+		}
+		addPageResource(filesByID, resourceByURL, SourceFileInfo{
+			URL:      resource.URL,
+			Type:     resource.Type,
+			MimeType: resource.MimeType,
+			FrameID:  tree.Frame.ID,
+		})
+	}
+
+	for _, child := range tree.ChildFrames {
+		collectPageResources(child, filesByID, resourceByURL)
+	}
+}
+
+func addPageResource(filesByID map[string]SourceFileInfo, resourceByURL map[string]string, file SourceFileInfo) {
+	if file.FrameID == "" || file.URL == "" {
+		return
+	}
+	file.ID = makeResourceSourceID(file.FrameID, file.URL)
+	file.CanSetBreakpoint = strings.EqualFold(file.Type, "Script") || strings.Contains(file.MimeType, "javascript")
+	filesByID[file.ID] = file
+	resourceByURL[file.URL] = file.ID
+}
+
+func makeResourceSourceID(frameID string, url string) string {
+	payload := base64.RawURLEncoding.EncodeToString([]byte(frameID + "\n" + url))
+	return "resource:" + payload
+}
+
+func sourceTypeRank(sourceType string) int {
+	switch strings.ToLower(sourceType) {
+	case "document":
+		return 0
+	case "script":
+		return 1
+	case "stylesheet":
+		return 2
+	case "xhr", "fetch":
+		return 3
+	case "image", "font", "media":
+		return 5
+	default:
+		return 4
+	}
+}
+
 // =============================================================================
 // DOM Inspector
 // =============================================================================
@@ -476,14 +942,24 @@ type DOMNode struct {
 	NodeType   int       `json:"nodeType"`
 	NodeName   string    `json:"nodeName"`
 	LocalName  string    `json:"localName"`
+	NodeValue  string    `json:"nodeValue"`
 	Attributes []string  `json:"attributes"`
 	ChildCount int       `json:"childCount"`
 	Children   []DOMNode `json:"children,omitempty"`
 }
 
+// DOMBreakpointInfo represents a DOM mutation breakpoint bound to a node.
+type DOMBreakpointInfo struct {
+	NodeID int    `json:"nodeId"`
+	Type   string `json:"type"`
+}
+
 var (
 	domRootNodeID   int
 	domRootNodeIDMu sync.Mutex
+
+	domBreakpoints   []DOMBreakpointInfo
+	domBreakpointsMu sync.Mutex
 )
 
 // EnableDOM enables the DOM domain and gets the document root.
@@ -723,6 +1199,97 @@ func (b *BrowserDebug) HideHighlight() error {
 		return fmt.Errorf("failed to hide highlight: %w", err)
 	}
 	return nil
+}
+
+// SetDOMBreakpoint pauses JavaScript execution when a DOM mutation touches nodeId.
+func (b *BrowserDebug) SetDOMBreakpoint(nodeId int, breakpointType string) error {
+	b.mu.Lock()
+	if !b.connected {
+		b.mu.Unlock()
+		return fmt.Errorf("not connected to CDP")
+	}
+	b.mu.Unlock()
+
+	if nodeId <= 0 {
+		return fmt.Errorf("node id must be greater than zero")
+	}
+	if !isValidDOMBreakpointType(breakpointType) {
+		return fmt.Errorf("invalid DOM breakpoint type: %s", breakpointType)
+	}
+
+	// DOM breakpoints surface as debugger pauses, so keep Debugger enabled.
+	if err := b.sendCommand("Debugger.enable", nil); err != nil {
+		return fmt.Errorf("failed to enable Debugger domain: %w", err)
+	}
+
+	if err := b.sendCommand("DOMDebugger.setDOMBreakpoint", map[string]interface{}{
+		"nodeId": nodeId,
+		"type":   breakpointType,
+	}); err != nil {
+		return fmt.Errorf("failed to set DOM breakpoint: %w", err)
+	}
+
+	domBreakpointsMu.Lock()
+	defer domBreakpointsMu.Unlock()
+	for _, bp := range domBreakpoints {
+		if bp.NodeID == nodeId && bp.Type == breakpointType {
+			return nil
+		}
+	}
+	domBreakpoints = append(domBreakpoints, DOMBreakpointInfo{NodeID: nodeId, Type: breakpointType})
+	return nil
+}
+
+// RemoveDOMBreakpoint removes a DOM mutation breakpoint from nodeId.
+func (b *BrowserDebug) RemoveDOMBreakpoint(nodeId int, breakpointType string) error {
+	b.mu.Lock()
+	if !b.connected {
+		b.mu.Unlock()
+		return fmt.Errorf("not connected to CDP")
+	}
+	b.mu.Unlock()
+
+	if nodeId <= 0 {
+		return fmt.Errorf("node id must be greater than zero")
+	}
+	if !isValidDOMBreakpointType(breakpointType) {
+		return fmt.Errorf("invalid DOM breakpoint type: %s", breakpointType)
+	}
+
+	if err := b.sendCommand("DOMDebugger.removeDOMBreakpoint", map[string]interface{}{
+		"nodeId": nodeId,
+		"type":   breakpointType,
+	}); err != nil {
+		return fmt.Errorf("failed to remove DOM breakpoint: %w", err)
+	}
+
+	domBreakpointsMu.Lock()
+	defer domBreakpointsMu.Unlock()
+	for i, bp := range domBreakpoints {
+		if bp.NodeID == nodeId && bp.Type == breakpointType {
+			domBreakpoints = append(domBreakpoints[:i], domBreakpoints[i+1:]...)
+			break
+		}
+	}
+	return nil
+}
+
+// GetDOMBreakpoints returns all active DOM mutation breakpoints.
+func (b *BrowserDebug) GetDOMBreakpoints() []DOMBreakpointInfo {
+	domBreakpointsMu.Lock()
+	defer domBreakpointsMu.Unlock()
+	result := make([]DOMBreakpointInfo, len(domBreakpoints))
+	copy(result, domBreakpoints)
+	return result
+}
+
+func isValidDOMBreakpointType(breakpointType string) bool {
+	switch breakpointType {
+	case "subtree-modified", "attribute-modified", "node-removed":
+		return true
+	default:
+		return false
+	}
 }
 
 // =============================================================================
@@ -1058,6 +1625,7 @@ func parseDOMNode(raw json.RawMessage) (*DOMNode, error) {
 		NodeType   int               `json:"nodeType"`
 		NodeName   string            `json:"nodeName"`
 		LocalName  string            `json:"localName"`
+		NodeValue  string            `json:"nodeValue"`
 		Attributes []string          `json:"attributes"`
 		ChildCount int               `json:"childNodeCount"`
 		Children   []json.RawMessage `json:"children"`
@@ -1071,6 +1639,7 @@ func parseDOMNode(raw json.RawMessage) (*DOMNode, error) {
 		NodeType:   nodeMap.NodeType,
 		NodeName:   nodeMap.NodeName,
 		LocalName:  nodeMap.LocalName,
+		NodeValue:  nodeMap.NodeValue,
 		Attributes: nodeMap.Attributes,
 		ChildCount: nodeMap.ChildCount,
 	}

--- a/docs/funzionalita.md
+++ b/docs/funzionalita.md
@@ -389,8 +389,8 @@ Tutte le funzionalità sono offline-first: nessun account, nessuna telemetria, n
 | D1.3 | **Network Monitor** | Cattura traffico pagina: URL, metodo, status, MIME, headers, timing, dimensione. Filtrabile per URL/metodo/tipo MIME (XHR, Doc, CSS, JS, Img, Font). Max 500 voci. |
 | D1.4 | **Body Richieste/Risposte** | Recupero body completi (POST data e response body) per voci catturate. |
 | D1.5 | **Console JavaScript** | Cattura eventi `consoleAPICalled` (log/error/warn/info). Eval espressioni JS nel contesto pagina con REPL. Max 200 voci. |
-| D1.6 | **Debugger JS** | Set/remove breakpoint con condizioni, pause/resume/step-over/step-into/step-out, stack call. |
-| D1.7 | **DOM Inspector** | Albero DOM con profondità configurabile, querySelector CSS, stili computati, highlight nodi. |
+| D1.6 | **Debugger JS** | Vista Sources combinata da script CDP e resource tree pagina, cache browser disabilitata via CDP, reload Sources senza cache, visualizzazione codice con numeri riga e syntax highlight minimale theme-aware, breakpoint cliccabili/condizionali anche via `scriptId`, riga corrente evidenziata in pausa, pause/resume/step-over/step-into/step-out, stack call. |
+| D1.7 | **DOM Inspector** | Albero DOM con profondità configurabile, nodi non-elemento visibili (document, doctype, text, comment), querySelector CSS, sorgente HTML formattata, stili computati, highlight nodi e breakpoint DOM su subtree/attributi/rimozione. |
 | D1.8 | **Storage Viewer** | Cookies (dominio, path, scadenza, HttpOnly, Secure, SameSite), localStorage, sessionStorage, IndexedDB. Elimina cookie. |
 | D1.9 | **Network Throttling** | Profili: No Throttling, Slow 3G, Fast 3G, Regular 4G, WiFi, Offline. Kbps/latenza custom. |
 | D1.10 | **Discovery Browser Attivi** | Scansiona porte 9222–9230 per trovare istanze browser con remote debugging già attivo. Mostra lista target (tab/pagine) per ogni browser scoperto con titolo, URL, favicon. |

--- a/frontend/src/components/browser-debug/DOMInspectorPanel.tsx
+++ b/frontend/src/components/browser-debug/DOMInspectorPanel.tsx
@@ -4,10 +4,17 @@ import {
   enableDOM,
   getDocument,
   getComputedStyleForNode,
+  getNodeHTML,
+  getPageSource,
   querySelector,
   highlightNode,
   hideHighlight,
+  getDOMBreakpoints,
+  setDOMBreakpoint,
+  removeDOMBreakpoint,
   type DOMNode,
+  type DOMBreakpointInfo,
+  type DOMBreakpointType,
 } from '@/lib/browser-debug-api'
 import {
   Code2,
@@ -15,6 +22,10 @@ import {
   ChevronDown,
   Search,
   Highlighter,
+  FileCode2,
+  RefreshCw,
+  Copy,
+  CircleDot,
 } from 'lucide-react'
 
 export type { DOMNode }
@@ -36,6 +47,46 @@ function formatAttributes(attributes: string[]): { name: string; value: string }
   return pairs
 }
 
+function formatHTMLSource(source: string): string {
+  const compact = source.replace(/>\s+</g, '><').trim()
+  const withBreaks = compact.replace(/></g, '>\n<')
+  const lines = withBreaks.split('\n')
+  let depth = 0
+
+  return lines
+    .map((rawLine) => {
+      const line = rawLine.trim()
+      if (!line) return ''
+      const closing = /^<\//.test(line)
+      const selfClosing =
+        /\/>$/.test(line) ||
+        /^<!/.test(line) ||
+        /^<\?/.test(line) ||
+        /^<(area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)\b/i.test(line)
+
+      if (closing) depth = Math.max(depth - 1, 0)
+      const formatted = `${'  '.repeat(depth)}${line}`
+      if (!closing && !selfClosing) depth += 1
+      return formatted
+    })
+    .join('\n')
+}
+
+function copyToClipboard(text: string) {
+  void navigator.clipboard?.writeText(text)
+}
+
+function compactNodeValue(value: string) {
+  const normalized = value.replace(/\s+/g, ' ').trim()
+  return normalized.length > 120 ? `${normalized.slice(0, 120)}...` : normalized
+}
+
+const DOM_BREAKPOINTS: Array<{ type: DOMBreakpointType; label: string }> = [
+  { type: 'subtree-modified', label: 'Subtree' },
+  { type: 'attribute-modified', label: 'Attributes' },
+  { type: 'node-removed', label: 'Removal' },
+]
+
 function DOMNodeRow({
   node,
   depth,
@@ -45,30 +96,76 @@ function DOMNodeRow({
   expandedNodes,
 }: DOMNodeRowProps) {
   const isElement = node.nodeType === 1
-  const isText = node.nodeType === 3
   const isExpanded = expandedNodes.has(node.nodeId)
-  const hasChildren = node.childCount > 0
+  const hasChildren = node.childCount > 0 || Boolean(node.children?.length)
   const isSelected = selectedNodeId === node.nodeId
 
-  if (isText) {
-    const text = node.nodeName === '#text' ? node.localName || '' : node.nodeName
-    if (!text.trim()) return null
-    return (
-      <div
-        className="flex items-center py-px"
-        style={{ paddingLeft: `${depth * 16 + 20}px` }}
-      >
-        <span className="text-text-3 text-[10px] font-mono truncate">
-          &quot;{text.trim().slice(0, 80)}
-          {text.trim().length > 80 ? '...' : ''}&quot;
+  const attrs = formatAttributes(node.attributes)
+  const nonElementValue = compactNodeValue(node.nodeValue || node.localName || '')
+
+  const renderNodeContent = () => {
+    if (isElement) {
+      return (
+        <span className="text-[10px] font-mono flex items-center gap-0.5 truncate">
+          <span className="text-text-3">&lt;</span>
+          <span className="text-accent font-medium">{node.localName || node.nodeName.toLowerCase()}</span>
+          {attrs.map((attr) => (
+            <span key={attr.name} className="ml-1">
+              <span className="text-info">{attr.name}</span>
+              <span className="text-text-3">=&quot;</span>
+              <span className="text-success">{attr.value}</span>
+              <span className="text-text-3">&quot;</span>
+            </span>
+          ))}
+          <span className="text-text-3">&gt;</span>
         </span>
-      </div>
+      )
+    }
+
+    if (node.nodeType === 3) {
+      const visibleText = nonElementValue || 'whitespace'
+      return (
+        <span className="text-[10px] font-mono flex items-center gap-1 truncate">
+          <span className="rounded border border-border-1 bg-surface-0 px-1 text-text-4">#text</span>
+          <span className={nonElementValue ? 'text-text-2' : 'text-text-4 italic'}>
+            &quot;{visibleText}&quot;
+          </span>
+        </span>
+      )
+    }
+
+    if (node.nodeType === 8) {
+      return (
+        <span className="text-[10px] font-mono flex items-center gap-1 truncate">
+          <span className="rounded border border-border-1 bg-surface-0 px-1 text-text-4">comment</span>
+          <span className="text-text-4 italic">&lt;!-- {nonElementValue || 'empty'} --&gt;</span>
+        </span>
+      )
+    }
+
+    if (node.nodeType === 9) {
+      return <span className="text-[10px] font-mono text-warning">#document</span>
+    }
+
+    if (node.nodeType === 10) {
+      return (
+        <span className="text-[10px] font-mono flex items-center gap-1 truncate">
+          <span className="text-text-3">&lt;!doctype</span>
+          <span className="text-warning">{node.nodeName.toLowerCase() || 'html'}</span>
+          <span className="text-text-3">&gt;</span>
+        </span>
+      )
+    }
+
+    return (
+      <span className="text-[10px] font-mono flex items-center gap-1 truncate">
+        <span className="rounded border border-border-1 bg-surface-0 px-1 text-text-4">
+          node {node.nodeType}
+        </span>
+        <span className="text-text-2">{node.nodeName || nonElementValue || 'unnamed'}</span>
+      </span>
     )
   }
-
-  if (!isElement) return null
-
-  const attrs = formatAttributes(node.attributes)
 
   return (
     <>
@@ -98,25 +195,13 @@ function DOMNodeRow({
           <div className="w-4 flex-shrink-0" />
         )}
 
-        <span className="text-[10px] font-mono flex items-center gap-0.5 truncate">
-          <span className="text-text-3">&lt;</span>
-          <span className="text-accent font-medium">{node.localName}</span>
-          {attrs.map((attr) => (
-            <span key={attr.name} className="ml-1">
-              <span className="text-green-400">{attr.name}</span>
-              <span className="text-text-3">=&quot;</span>
-              <span className="text-text-2">{attr.value}</span>
-              <span className="text-text-3">&quot;</span>
-            </span>
-          ))}
-          <span className="text-text-3">&gt;</span>
-        </span>
+        {renderNodeContent()}
       </div>
 
       {isExpanded &&
-        node.children?.map((child) => (
+        node.children?.map((child, index) => (
           <DOMNodeRow
-            key={child.nodeId}
+            key={`${child.nodeId}-${index}`}
             node={child}
             depth={depth + 1}
             selectedNodeId={selectedNodeId}
@@ -136,6 +221,11 @@ export function DOMInspectorPanel() {
   const [expandedNodes, setExpandedNodes] = useState<Set<number>>(new Set())
   const [selectorQuery, setSelectorQuery] = useState('')
   const [initialized, setInitialized] = useState(false)
+  const [activeView, setActiveView] = useState<'elements' | 'source'>('elements')
+  const [pageSource, setPageSource] = useState('')
+  const [sourceLoading, setSourceLoading] = useState(false)
+  const [selectedHTML, setSelectedHTML] = useState('')
+  const [domBreakpoints, setDomBreakpoints] = useState<DOMBreakpointInfo[]>([])
 
   // Initialize DOM domain
   useEffect(() => {
@@ -146,14 +236,37 @@ export function DOMInspectorPanel() {
         setRootNode(doc)
         setInitialized(true)
       }
+      setDomBreakpoints(await getDOMBreakpoints())
     }
     init()
   }, [])
 
+  const refreshSource = useCallback(async () => {
+    setSourceLoading(true)
+    const source = await getPageSource()
+    setPageSource(source ? formatHTMLSource(source) : '')
+    setSourceLoading(false)
+  }, [])
+
+  useEffect(() => {
+    if (activeView === 'source' && !pageSource && !sourceLoading) {
+      void refreshSource()
+    }
+  }, [activeView, pageSource, refreshSource, sourceLoading])
+
   const handleSelect = useCallback(async (node: DOMNode) => {
     setSelectedNode(node)
-    const styles = await getComputedStyleForNode(node.nodeId)
+    if (node.nodeType !== 1) {
+      setComputedStyles({})
+      setSelectedHTML(node.nodeValue || node.nodeName || 'No node value available')
+      return
+    }
+    const [styles, html] = await Promise.all([
+      getComputedStyleForNode(node.nodeId),
+      getNodeHTML(node.nodeId),
+    ])
     setComputedStyles(styles)
+    setSelectedHTML(html)
   }, [])
 
   const handleExpand = useCallback(
@@ -188,8 +301,13 @@ export function DOMInspectorPanel() {
     const result = await querySelector(selectorQuery.trim())
     if (result) {
       setSelectedNode(result)
-      const styles = await getComputedStyleForNode(result.nodeId)
+      const [styles, html] = await Promise.all([
+        getComputedStyleForNode(result.nodeId),
+        getNodeHTML(result.nodeId),
+      ])
       setComputedStyles(styles)
+      setSelectedHTML(html)
+      await highlightNode(result.nodeId)
     }
   }, [selectorQuery])
 
@@ -203,13 +321,50 @@ export function DOMInspectorPanel() {
     await hideHighlight()
   }, [])
 
+  const handleToggleDOMBreakpoint = useCallback(
+    async (type: DOMBreakpointType) => {
+      if (!selectedNode) return
+      const active = domBreakpoints.some(
+        (bp) => bp.nodeId === selectedNode.nodeId && bp.type === type
+      )
+      if (active) {
+        await removeDOMBreakpoint(selectedNode.nodeId, type)
+      } else {
+        await setDOMBreakpoint(selectedNode.nodeId, type)
+      }
+      setDomBreakpoints(await getDOMBreakpoints())
+    },
+    [domBreakpoints, selectedNode]
+  )
+
   const styleEntries = Object.entries(computedStyles)
+  const sourceLines = pageSource ? pageSource.split('\n') : []
 
   return (
     <div className="flex flex-col h-full overflow-hidden bg-surface-1">
       {/* Top toolbar */}
       <div className="flex items-center h-8 px-3 gap-2 border-b border-border-1 bg-surface-0 flex-shrink-0">
         <Code2 size={12} className="text-text-3" />
+        <div className="flex items-center h-6 rounded border border-border-1 bg-surface-1 overflow-hidden">
+          <button
+            onClick={() => setActiveView('elements')}
+            className={cn(
+              'h-6 px-2 text-[10px] font-medium transition-colors',
+              activeView === 'elements' ? 'bg-accent/15 text-accent' : 'text-text-3 hover:text-text-1'
+            )}
+          >
+            Elements
+          </button>
+          <button
+            onClick={() => setActiveView('source')}
+            className={cn(
+              'h-6 px-2 text-[10px] font-medium transition-colors border-l border-border-1',
+              activeView === 'source' ? 'bg-accent/15 text-accent' : 'text-text-3 hover:text-text-1'
+            )}
+          >
+            Source
+          </button>
+        </div>
         <div className="relative flex-1 max-w-xs">
           <Search
             size={10}
@@ -237,18 +392,58 @@ export function DOMInspectorPanel() {
             Highlight
           </button>
         )}
+        {activeView === 'source' && (
+          <>
+            <button
+              onClick={refreshSource}
+              title="Refresh source"
+              className="h-6 w-6 rounded flex items-center justify-center text-text-2 hover:text-text-1 hover:bg-surface-2 transition-colors"
+            >
+              <RefreshCw size={11} />
+            </button>
+            <button
+              onClick={() => copyToClipboard(pageSource)}
+              title="Copy source"
+              disabled={!pageSource}
+              className="h-6 w-6 rounded flex items-center justify-center text-text-2 hover:text-text-1 hover:bg-surface-2 transition-colors disabled:opacity-30"
+            >
+              <Copy size={11} />
+            </button>
+          </>
+        )}
       </div>
 
       {/* Main content */}
       <div className="flex flex-1 min-h-0">
         {/* DOM Tree */}
         <div className="flex-1 overflow-y-auto py-1 border-r border-border-1">
-          {!initialized && (
+          {activeView === 'source' ? (
+            <div className="h-full min-h-0 overflow-auto bg-surface-0 font-mono text-[10px] leading-4">
+              {sourceLoading && (
+                <div className="flex items-center justify-center h-full text-text-3 text-xs">
+                  Loading source...
+                </div>
+              )}
+              {!sourceLoading && !pageSource && (
+                <div className="flex items-center justify-center h-full text-text-3 text-xs">
+                  No source available
+                </div>
+              )}
+              {!sourceLoading &&
+                sourceLines.map((line, index) => (
+                  <div key={index} className="flex min-w-max hover:bg-surface-2/60">
+                    <span className="w-12 flex-shrink-0 select-none border-r border-border-1 pr-2 text-right text-text-4 bg-surface-1">
+                      {index + 1}
+                    </span>
+                    <code className="whitespace-pre px-3 text-text-2">{line}</code>
+                  </div>
+                ))}
+            </div>
+          ) : !initialized ? (
             <div className="flex items-center justify-center h-full text-text-3 text-xs">
               Loading DOM...
             </div>
-          )}
-          {rootNode && (
+          ) : rootNode && (
             <DOMNodeRow
               node={rootNode}
               depth={0}
@@ -262,6 +457,51 @@ export function DOMInspectorPanel() {
 
         {/* Computed Styles */}
         <div className="w-[280px] overflow-y-auto flex-shrink-0">
+          <div className="px-2 py-1.5 border-b border-border-1 bg-surface-0">
+            <span className="text-[10px] text-text-3 uppercase tracking-wide font-medium">
+              Selected Node
+            </span>
+          </div>
+          {!selectedNode && (
+            <div className="px-2 py-3 text-text-3 text-[10px]">
+              Select an element to inspect source, styles and DOM breakpoints
+            </div>
+          )}
+          {selectedNode && (
+            <div className="px-2 py-2 space-y-2 border-b border-border-1">
+              <div className="flex items-center gap-1 text-[10px] font-mono">
+                <FileCode2 size={11} className="text-text-3 flex-shrink-0" />
+                <span className="text-accent truncate">{selectedNode.localName || selectedNode.nodeName}</span>
+                <span className="text-text-4">#{selectedNode.nodeId}</span>
+              </div>
+              <div className="max-h-28 overflow-auto rounded border border-border-1 bg-surface-0 p-2 text-[10px] font-mono text-text-2 whitespace-pre-wrap break-words">
+                {selectedHTML || 'No outerHTML available'}
+              </div>
+              <div className="flex items-center gap-1">
+                {DOM_BREAKPOINTS.map((item) => {
+                  const active = domBreakpoints.some(
+                    (bp) => bp.nodeId === selectedNode.nodeId && bp.type === item.type
+                  )
+                  return (
+                    <button
+                      key={item.type}
+                      onClick={() => handleToggleDOMBreakpoint(item.type)}
+                      title={`Toggle ${item.label} DOM breakpoint`}
+                      className={cn(
+                        'h-6 px-2 rounded border text-[10px] flex items-center gap-1 transition-colors',
+                        active
+                          ? 'border-red-500/40 bg-red-500/10 text-red-300'
+                          : 'border-border-1 bg-surface-0 text-text-3 hover:text-text-1'
+                      )}
+                    >
+                      <CircleDot size={9} />
+                      {item.label}
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+          )}
           <div className="px-2 py-1.5 border-b border-border-1 bg-surface-0">
             <span className="text-[10px] text-text-3 uppercase tracking-wide font-medium">
               Computed Styles

--- a/frontend/src/components/browser-debug/DebuggerPanel.tsx
+++ b/frontend/src/components/browser-debug/DebuggerPanel.tsx
@@ -1,11 +1,15 @@
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { cn } from '@/lib/utils'
 import {
   enableDebugger,
   disableDebugger,
   setBreakpoint,
+  setBreakpointByScriptID,
   removeBreakpoint,
   getBreakpoints,
+  getSourceFiles,
+  getSourceFileContent,
+  reloadPageNoCache,
   resume,
   stepOver,
   stepInto,
@@ -14,6 +18,7 @@ import {
   type BreakpointInfo,
   type PausedState,
   type CallFrame,
+  type SourceFileInfo,
 } from '@/lib/browser-debug-api'
 import {
   Bug,
@@ -25,34 +30,272 @@ import {
   X,
   Power,
   Pause,
+  RefreshCw,
+  FileCode2,
+  CircleDot,
+  Search,
+  ChevronRight,
 } from 'lucide-react'
 
-export type { BreakpointInfo, CallFrame, PausedState }
+export type { BreakpointInfo, CallFrame, PausedState, SourceFileInfo }
+
+function sourceLabel(source: SourceFileInfo) {
+  if (!source.url) return source.scriptId ? `inline script ${source.scriptId}` : source.id
+  try {
+    const url = new URL(source.url)
+    return url.pathname.split('/').filter(Boolean).pop() || url.hostname
+  } catch {
+    return source.url.split('/').filter(Boolean).pop() || source.url
+  }
+}
+
+function sourceSubtitle(source: SourceFileInfo) {
+  if (!source.url) return source.scriptId ? `scriptId ${source.scriptId}` : source.type
+  try {
+    const url = new URL(source.url)
+    return `${source.type || 'Source'} - ${url.hostname}${url.pathname}`
+  } catch {
+    return `${source.type || 'Source'} - ${source.url}`
+  }
+}
+
+function breakpointLineKey(kind: 'script' | 'url', id: string, lineNumber: number) {
+  return `${kind}:${id}:${lineNumber}`
+}
+
+function sourceLineKeys(source: SourceFileInfo, lineNumber: number) {
+  const keys: string[] = []
+  if (source.scriptId) keys.push(breakpointLineKey('script', source.scriptId, lineNumber))
+  if (source.url) keys.push(breakpointLineKey('url', source.url, lineNumber))
+  return keys
+}
+
+function sourceTone(source: SourceFileInfo) {
+  const type = source.type.toLowerCase()
+  if (type === 'document') return 'text-info border-info/25 bg-info/10'
+  if (type === 'script') return 'text-accent border-accent/25 bg-accent/10'
+  if (type === 'stylesheet') return 'text-success border-success/25 bg-success/10'
+  if (type === 'image' || type === 'font' || type === 'media') return 'text-text-4 border-border-1 bg-surface-1'
+  return 'text-warning border-warning/25 bg-warning/10'
+}
+
+const JS_KEYWORDS = new Set([
+  'async',
+  'await',
+  'break',
+  'case',
+  'catch',
+  'class',
+  'const',
+  'continue',
+  'debugger',
+  'default',
+  'delete',
+  'do',
+  'else',
+  'export',
+  'extends',
+  'finally',
+  'for',
+  'from',
+  'function',
+  'if',
+  'import',
+  'in',
+  'instanceof',
+  'let',
+  'new',
+  'of',
+  'return',
+  'static',
+  'super',
+  'switch',
+  'this',
+  'throw',
+  'try',
+  'typeof',
+  'var',
+  'void',
+  'while',
+  'with',
+  'yield',
+])
+
+const JS_LITERALS = new Set(['true', 'false', 'null', 'undefined', 'NaN', 'Infinity'])
+
+function tokenClass(token: string) {
+  if (token.startsWith('//') || token.startsWith('/*')) return 'text-text-4 italic'
+  if (token.startsWith('"') || token.startsWith("'") || token.startsWith('`')) return 'text-success'
+  if (/^\d/.test(token)) return 'text-warning'
+  if (JS_LITERALS.has(token)) return 'text-info'
+  if (JS_KEYWORDS.has(token)) return 'text-accent font-medium'
+  if (/^[{}()[\].,;:+\-*/%=&|!?<>~^]+$/.test(token)) return 'text-text-3'
+  return 'text-text-2'
+}
+
+function renderHighlightedJS(line: string) {
+  const tokenPattern =
+    /(\/\/.*|\/\*.*?\*\/|`(?:\\.|[^`\\])*`|'(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*"|\b(?:true|false|null|undefined|NaN|Infinity)\b|\b\d+(?:\.\d+)?(?:e[+-]?\d+)?\b|\b[A-Za-z_$][\w$]*\b|[{}()[\].,;:+\-*/%=&|!?<>~^]+)/gi
+  const parts: Array<string | JSX.Element> = []
+  let cursor = 0
+  let match: RegExpExecArray | null
+  let index = 0
+
+  while ((match = tokenPattern.exec(line)) !== null) {
+    if (match.index > cursor) parts.push(line.slice(cursor, match.index))
+    const token = match[0]
+    parts.push(
+      <span key={`${index}-${match.index}`} className={tokenClass(token)}>
+        {token}
+      </span>
+    )
+    cursor = match.index + token.length
+    index += 1
+  }
+
+  if (cursor < line.length) parts.push(line.slice(cursor))
+  return parts.length ? parts : line
+}
+
+function renderHighlightedHTML(line: string) {
+  const tokenPattern =
+    /(<!--.*?-->|<\/?[A-Za-z][\w:-]*|\/?>|[A-Za-z_:][\w:.-]*(?=\=)|"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')/g
+  const parts: Array<string | JSX.Element> = []
+  let cursor = 0
+  let match: RegExpExecArray | null
+  let index = 0
+
+  while ((match = tokenPattern.exec(line)) !== null) {
+    if (match.index > cursor) parts.push(line.slice(cursor, match.index))
+    const token = match[0]
+    const className = token.startsWith('<!--')
+      ? 'text-text-4 italic'
+      : token.startsWith('<')
+        ? 'text-accent'
+        : token === '>' || token === '/>'
+          ? 'text-text-3'
+          : token.startsWith('"') || token.startsWith("'")
+            ? 'text-success'
+            : 'text-info'
+    parts.push(<span key={`${index}-${match.index}`} className={className}>{token}</span>)
+    cursor = match.index + token.length
+    index += 1
+  }
+
+  if (cursor < line.length) parts.push(line.slice(cursor))
+  return parts.length ? parts : line
+}
+
+function renderHighlightedCSS(line: string) {
+  const tokenPattern = /(\/\*.*?\*\/|#[\w-]+|\.[\w-]+|--[\w-]+|[A-Za-z-]+(?=\s*:)|"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\b\d+(?:\.\d+)?(?:px|rem|em|vh|vw|%|s|ms)?\b|[{}:;,()>+~*])/g
+  const parts: Array<string | JSX.Element> = []
+  let cursor = 0
+  let match: RegExpExecArray | null
+  let index = 0
+
+  while ((match = tokenPattern.exec(line)) !== null) {
+    if (match.index > cursor) parts.push(line.slice(cursor, match.index))
+    const token = match[0]
+    const className = token.startsWith('/*')
+      ? 'text-text-4 italic'
+      : token.startsWith('"') || token.startsWith("'")
+        ? 'text-success'
+        : /^\d/.test(token)
+          ? 'text-warning'
+          : token.startsWith('.') || token.startsWith('#')
+            ? 'text-accent'
+            : /^[{}:;,()>+~*]$/.test(token)
+              ? 'text-text-3'
+              : 'text-info'
+    parts.push(<span key={`${index}-${match.index}`} className={className}>{token}</span>)
+    cursor = match.index + token.length
+    index += 1
+  }
+
+  if (cursor < line.length) parts.push(line.slice(cursor))
+  return parts.length ? parts : line
+}
+
+function renderHighlightedSource(line: string, source: SourceFileInfo | null) {
+  const type = source?.type.toLowerCase() ?? ''
+  const mime = source?.mimeType.toLowerCase() ?? ''
+  if (type === 'document' || mime.includes('html') || mime.includes('xml')) return renderHighlightedHTML(line)
+  if (type === 'stylesheet' || mime.includes('css')) return renderHighlightedCSS(line)
+  if (type === 'script' || mime.includes('javascript') || mime.includes('json')) return renderHighlightedJS(line)
+  return line
+}
 
 export function DebuggerPanel() {
   const [enabled, setEnabled] = useState(false)
   const [breakpoints, setBreakpoints] = useState<BreakpointInfo[]>([])
   const [pausedState, setPausedState] = useState<PausedState | null>(null)
+  const [sources, setSources] = useState<SourceFileInfo[]>([])
+  const [selectedSource, setSelectedSource] = useState<SourceFileInfo | null>(null)
+  const [sourceContent, setSourceContent] = useState('')
+  const [scriptFilter, setScriptFilter] = useState('')
+  const [sourceLoading, setSourceLoading] = useState(false)
 
-  // Add breakpoint form
   const [bpUrl, setBpUrl] = useState('')
   const [bpLine, setBpLine] = useState('')
   const [bpCondition, setBpCondition] = useState('')
 
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const activeLineRef = useRef<HTMLDivElement | null>(null)
 
-  // Poll paused state when debugger is enabled
-  useEffect(() => {
-    if (enabled) {
-      const poll = async () => {
-        const state = await getPausedState()
-        setPausedState(state)
+  const refreshBreakpoints = useCallback(async () => {
+    setBreakpoints(await getBreakpoints())
+  }, [])
+
+  const refreshSources = useCallback(async () => {
+    const nextSources = await getSourceFiles()
+    setSources(nextSources)
+    setSelectedSource((current) => {
+      if (current && nextSources.some((source) => source.id === current.id)) {
+        return current
       }
-      poll()
-      pollRef.current = setInterval(poll, 500)
-    } else {
-      setPausedState(null)
+      return nextSources[0] ?? null
+    })
+  }, [])
+
+  const hardReloadSources = useCallback(async () => {
+    setSourceLoading(true)
+    setSourceContent('')
+    setSelectedSource(null)
+    setSources([])
+    setBreakpoints([])
+    setPausedState(null)
+
+    await reloadPageNoCache()
+    window.setTimeout(() => {
+      void refreshSources()
+      void refreshBreakpoints()
+      setSourceLoading(false)
+    }, 450)
+  }, [refreshBreakpoints, refreshSources])
+
+  const loadSourceContent = useCallback(async (source: SourceFileInfo | null) => {
+    if (!source) {
+      setSourceContent('')
+      return
     }
+    setSourceLoading(true)
+    const content = await getSourceFileContent(source.id)
+    setSourceContent(content)
+    setSourceLoading(false)
+  }, [])
+
+  useEffect(() => {
+    if (!enabled) {
+      setPausedState(null)
+      return
+    }
+
+    const poll = async () => {
+      const state = await getPausedState()
+      setPausedState(state)
+    }
+    poll()
+    pollRef.current = setInterval(poll, 500)
 
     return () => {
       if (pollRef.current) {
@@ -62,33 +305,57 @@ export function DebuggerPanel() {
     }
   }, [enabled])
 
-  const refreshBreakpoints = useCallback(async () => {
-    const bps = await getBreakpoints()
-    setBreakpoints(bps)
-  }, [])
+  useEffect(() => {
+    if (!enabled) return
+    void refreshBreakpoints()
+    void refreshSources()
+  }, [enabled, refreshBreakpoints, refreshSources])
 
   useEffect(() => {
-    if (enabled) {
-      refreshBreakpoints()
+    void loadSourceContent(selectedSource)
+  }, [selectedSource, loadSourceContent])
+
+  useEffect(() => {
+    if (!pausedState?.paused) return
+    const match = sources.find((source) =>
+      (pausedState.scriptId && source.scriptId === pausedState.scriptId) ||
+      (pausedState.scriptUrl && source.url === pausedState.scriptUrl)
+    )
+    if (match) {
+      setSelectedSource(match)
+    } else {
+      void refreshSources()
     }
-  }, [enabled, refreshBreakpoints])
+  }, [pausedState, refreshSources, sources])
+
+  useEffect(() => {
+    if (!pausedState?.paused || !activeLineRef.current) return
+    activeLineRef.current.scrollIntoView({ block: 'center' })
+  }, [pausedState?.paused, pausedState?.scriptId, pausedState?.lineNumber, selectedSource?.id, sourceContent])
 
   const handleToggleDebugger = useCallback(async () => {
     if (enabled) {
       await disableDebugger()
       setEnabled(false)
       setBreakpoints([])
+      setSources([])
+      setSelectedSource(null)
+      setSourceContent('')
     } else {
       await enableDebugger()
       setEnabled(true)
+      setTimeout(() => {
+        void refreshSources()
+        void refreshBreakpoints()
+      }, 250)
     }
-  }, [enabled])
+  }, [enabled, refreshBreakpoints, refreshSources])
 
   const handleAddBreakpoint = useCallback(async () => {
-    const line = parseInt(bpLine, 10)
-    if (!bpUrl || isNaN(line)) return
+    const displayLine = parseInt(bpLine, 10)
+    if (!bpUrl || Number.isNaN(displayLine) || displayLine < 1) return
 
-    await setBreakpoint(bpUrl, line, bpCondition)
+    await setBreakpoint(bpUrl, displayLine - 1, bpCondition)
     setBpUrl('')
     setBpLine('')
     setBpCondition('')
@@ -119,13 +386,56 @@ export function DebuggerPanel() {
     await stepOut()
   }, [])
 
+  const handleToggleLineBreakpoint = useCallback(
+    async (lineIndex: number) => {
+      if (!selectedSource?.canSetBreakpoint) return
+      const existing = breakpoints.find(
+        (bp) =>
+          bp.lineNumber === lineIndex &&
+          ((selectedSource.scriptId && bp.scriptId === selectedSource.scriptId) ||
+            (selectedSource.url && bp.scriptUrl === selectedSource.url))
+      )
+      if (existing) {
+        await removeBreakpoint(existing.id)
+      } else if (selectedSource.scriptId) {
+        await setBreakpointByScriptID(selectedSource.scriptId, lineIndex, 0, '')
+      } else if (selectedSource.url) {
+        await setBreakpoint(selectedSource.url, lineIndex, '')
+      } else {
+        return
+      }
+      await refreshBreakpoints()
+    },
+    [breakpoints, refreshBreakpoints, selectedSource]
+  )
+
+  const filteredSources = useMemo(() => {
+    const query = scriptFilter.trim().toLowerCase()
+    if (!query) return sources
+    return sources.filter((source) => {
+      const label = sourceLabel(source).toLowerCase()
+      const subtitle = sourceSubtitle(source).toLowerCase()
+      return label.includes(query) || subtitle.includes(query)
+    })
+  }, [scriptFilter, sources])
+
+  const breakpointsByLine = useMemo(() => {
+    const index = new Map<string, BreakpointInfo>()
+    for (const bp of breakpoints) {
+      if (bp.scriptId) index.set(breakpointLineKey('script', bp.scriptId, bp.lineNumber), bp)
+      if (bp.scriptUrl) index.set(breakpointLineKey('url', bp.scriptUrl, bp.lineNumber), bp)
+    }
+    return index
+  }, [breakpoints])
+
+  const sourceLines = sourceContent ? sourceContent.split('\n') : []
+  const canSetSourceBreakpoints = Boolean(enabled && selectedSource?.canSetBreakpoint && (selectedSource.scriptId || selectedSource.url))
+
   return (
     <div className="flex flex-col h-full overflow-hidden bg-surface-1">
-      {/* Top bar */}
       <div className="flex items-center h-9 px-3 gap-2 border-b border-border-1 bg-surface-0 flex-shrink-0">
         <Bug size={12} className="text-text-3" />
 
-        {/* Toggle */}
         <button
           onClick={handleToggleDebugger}
           className={cn(
@@ -136,12 +446,11 @@ export function DebuggerPanel() {
           )}
         >
           <Power size={10} />
-          {enabled ? 'Disable Debugger' : 'Enable Debugger'}
+          {enabled ? 'Disable' : 'Enable'}
         </button>
 
         <div className="w-px h-5 bg-border-1" />
 
-        {/* Stepping controls */}
         <button
           onClick={handleResume}
           disabled={!enabled || !pausedState?.paused}
@@ -174,73 +483,216 @@ export function DebuggerPanel() {
         >
           <ArrowUpFromLine size={12} />
         </button>
-      </div>
 
-      {/* Main content */}
-      <div className="flex-1 overflow-y-auto px-3 py-2 space-y-4">
-        {/* Paused state indicator */}
+        <div className="w-px h-5 bg-border-1" />
+
+        <button
+          onClick={() => {
+            void hardReloadSources()
+          }}
+          disabled={!enabled}
+          title="Reload without cache"
+          className="h-6 w-6 rounded flex items-center justify-center text-text-2 hover:text-text-1 hover:bg-surface-2 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+        >
+          <RefreshCw size={12} />
+        </button>
+
         {pausedState?.paused && (
-          <div className="rounded border border-yellow-500/30 bg-yellow-500/5 p-2">
-            <div className="flex items-center gap-2 text-xs text-yellow-400 font-medium">
-              <Pause size={12} />
-              Paused: {pausedState.reason}
-            </div>
-            <div className="mt-1 text-[10px] text-text-2 font-mono">
-              {pausedState.scriptUrl}:{pausedState.lineNumber}
-            </div>
-
-            {/* Call Frames */}
-            {pausedState.callFrames.length > 0 && (
-              <div className="mt-2 space-y-0.5">
-                <div className="text-[10px] text-text-3 uppercase tracking-wide font-medium">
-                  Call Stack
-                </div>
-                {pausedState.callFrames.map((frame) => (
-                  <div
-                    key={frame.id}
-                    className="flex items-center gap-2 text-[10px] font-mono text-text-2 py-0.5"
-                  >
-                    <span className="text-accent">
-                      {frame.functionName || '(anonymous)'}
-                    </span>
-                    <span className="text-text-3 truncate">
-                      {frame.url}:{frame.lineNumber}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            )}
+          <div className="ml-auto flex items-center gap-2 rounded border border-yellow-500/30 bg-yellow-500/5 px-2 h-6 text-[10px] text-yellow-300 font-mono">
+            <Pause size={11} />
+            {pausedState.reason || 'paused'} at {pausedState.scriptUrl || pausedState.scriptId || 'anonymous'}:
+            {pausedState.lineNumber + 1}
           </div>
         )}
+      </div>
 
-        {/* Breakpoints section */}
-        <div>
-          <div className="text-[10px] text-text-3 uppercase tracking-wide font-medium mb-2">
-            Breakpoints
+      <div className="flex flex-1 min-h-0">
+        <aside className="w-[280px] flex-shrink-0 border-r border-border-1 bg-surface-0 flex flex-col min-h-0">
+          <div className="h-8 px-2 border-b border-border-1 flex items-center gap-2">
+            <FileCode2 size={12} className="text-text-3" />
+            <span className="text-[10px] uppercase tracking-wide font-medium text-text-3">
+              Sources
+            </span>
+            <span className="ml-auto text-[10px] text-text-4">{sources.length}</span>
+          </div>
+          <div className="p-2 border-b border-border-1">
+            <div className="relative">
+              <Search size={10} className="absolute left-2 top-1/2 -translate-y-1/2 text-text-3" />
+              <input
+                value={scriptFilter}
+                onChange={(e) => setScriptFilter(e.target.value)}
+                placeholder="Filter sources..."
+                className="h-6 w-full pl-6 pr-2 rounded bg-surface-1 border border-border-1 text-[10px] text-text-1 font-mono placeholder:text-text-3 focus:outline-none focus:border-accent"
+              />
+            </div>
+          </div>
+          <div className="flex-1 min-h-0 overflow-y-auto">
+            {!enabled && (
+              <div className="px-3 py-4 text-xs text-text-3">
+                Enable the debugger to load page sources.
+              </div>
+            )}
+            {enabled && filteredSources.length === 0 && (
+              <div className="px-3 py-4 text-xs text-text-3">
+                No source files captured yet. Refresh after the page loads.
+              </div>
+            )}
+            {filteredSources.map((source) => (
+              <button
+                key={source.id}
+                onClick={() => setSelectedSource(source)}
+                className={cn(
+                  'w-full px-2 py-1.5 text-left border-b border-border-1/60 hover:bg-surface-2 transition-colors',
+                  selectedSource?.id === source.id && 'bg-accent/10'
+                )}
+              >
+                <div className="flex items-center gap-1.5">
+                  <span className={cn('rounded border px-1 text-[8px] uppercase tracking-wide', sourceTone(source))}>
+                    {source.type || 'src'}
+                  </span>
+                  <span className="text-[11px] text-text-1 font-mono truncate">
+                    {sourceLabel(source)}
+                  </span>
+                </div>
+                <div className="text-[9px] text-text-4 font-mono truncate">
+                  {sourceSubtitle(source)}
+                </div>
+              </button>
+            ))}
+          </div>
+        </aside>
+
+        <main className="flex-1 min-w-0 flex flex-col bg-surface-1">
+          <div className="h-8 px-3 border-b border-border-1 bg-surface-0 flex items-center gap-2">
+            <span className="text-[10px] text-text-3 uppercase tracking-wide font-medium">
+              Source
+            </span>
+            {selectedSource && (
+              <span className="text-[10px] text-text-2 font-mono truncate">
+                {selectedSource.url || `inline script ${selectedSource.scriptId}`}
+              </span>
+            )}
+            {selectedSource && !selectedSource.canSetBreakpoint && (
+              <span className="ml-auto text-[10px] text-yellow-300">
+                Read-only resource
+              </span>
+            )}
+          </div>
+
+          <div className="flex-1 min-h-0 overflow-auto bg-surface-0 font-mono text-[10px] leading-4">
+            {sourceLoading && (
+              <div className="flex items-center justify-center h-full text-xs text-text-3">
+                Loading source...
+              </div>
+            )}
+            {!sourceLoading && !selectedSource && (
+              <div className="flex items-center justify-center h-full text-xs text-text-3">
+                Select a source file to inspect its content
+              </div>
+            )}
+            {!sourceLoading && selectedSource && sourceLines.length === 0 && (
+              <div className="flex items-center justify-center h-full text-xs text-text-3">
+                Source is empty or unavailable
+              </div>
+            )}
+            {!sourceLoading &&
+              sourceLines.map((line, index) => {
+                const bp = selectedSource
+                  ? sourceLineKeys(selectedSource, index)
+                    .map((key) => breakpointsByLine.get(key))
+                    .find(Boolean)
+                  : undefined
+                const isPausedLine =
+                  pausedState?.paused &&
+                  selectedSource &&
+                  ((pausedState.scriptId && selectedSource.scriptId === pausedState.scriptId) ||
+                    (pausedState.scriptUrl && selectedSource.url === pausedState.scriptUrl)) &&
+                  pausedState.lineNumber === index
+
+                return (
+                  <div
+                    key={index}
+                    ref={isPausedLine ? activeLineRef : undefined}
+                    className={cn(
+                      'group flex min-w-max border-l-2 border-transparent',
+                      isPausedLine
+                        ? 'border-warning bg-warning/20 shadow-[inset_0_0_0_1px_color-mix(in_oklab,var(--color-warning)_35%,transparent)]'
+                        : 'hover:bg-surface-2/60'
+                    )}
+                  >
+                    <button
+                      onClick={() => handleToggleLineBreakpoint(index)}
+                      disabled={!canSetSourceBreakpoints}
+                      title={
+                        canSetSourceBreakpoints
+                          ? bp
+                            ? 'Remove breakpoint'
+                            : 'Set breakpoint'
+                          : 'Select a breakpoint-capable source'
+                      }
+                      className={cn(
+                        'w-7 flex-shrink-0 border-r border-border-1 bg-surface-1 flex items-center justify-center disabled:cursor-not-allowed',
+                        isPausedLine && 'bg-warning/15'
+                      )}
+                    >
+                      {isPausedLine ? (
+                        <ChevronRight size={12} className="text-warning" />
+                      ) : bp ? (
+                        <CircleDot size={9} className="text-red-400" />
+                      ) : (
+                        <span className="h-2 w-2 rounded-full opacity-0 group-hover:opacity-40 bg-text-3" />
+                      )}
+                    </button>
+                    <span
+                      className={cn(
+                        'w-12 flex-shrink-0 select-none border-r border-border-1 pr-2 text-right text-text-4 bg-surface-1',
+                        isPausedLine && 'bg-warning/15 text-warning font-medium'
+                      )}
+                    >
+                      {index + 1}
+                    </span>
+                    <code
+                      className={cn(
+                        'whitespace-pre px-3 text-text-2',
+                        isPausedLine && 'text-text-1'
+                      )}
+                    >
+                      {renderHighlightedSource(line, selectedSource)}
+                    </code>
+                  </div>
+                )
+              })}
+          </div>
+        </main>
+
+        <aside className="w-[300px] flex-shrink-0 border-l border-border-1 bg-surface-1 overflow-y-auto">
+          <div className="px-2 py-1.5 border-b border-border-1 bg-surface-0">
+            <span className="text-[10px] text-text-3 uppercase tracking-wide font-medium">
+              Breakpoints
+            </span>
           </div>
 
           {breakpoints.length === 0 && (
-            <div className="text-xs text-text-3 py-1">
-              No breakpoints set
-            </div>
+            <div className="px-3 py-3 text-xs text-text-3">No breakpoints set</div>
           )}
 
-          <div className="space-y-1">
+          <div className="p-2 space-y-1">
             {breakpoints.map((bp) => (
               <div
                 key={bp.id}
                 className="flex items-center gap-2 text-[10px] font-mono bg-surface-0 rounded px-2 py-1 border border-border-1"
               >
                 <span className="text-text-1 truncate flex-1">
-                  {bp.scriptUrl}:{bp.lineNumber}
+                  {bp.scriptUrl || bp.scriptId || bp.id}:{bp.lineNumber + 1}
                 </span>
                 {bp.condition && (
-                  <span className="text-yellow-400 text-[9px] truncate max-w-[120px]">
+                  <span className="text-yellow-400 text-[9px] truncate max-w-[90px]">
                     if: {bp.condition}
                   </span>
                 )}
                 <button
                   onClick={() => handleRemoveBreakpoint(bp.id)}
+                  title="Remove breakpoint"
                   className="h-4 w-4 rounded flex items-center justify-center text-text-3 hover:text-red-400 hover:bg-red-500/10 transition-colors flex-shrink-0"
                 >
                   <X size={10} />
@@ -249,31 +701,31 @@ export function DebuggerPanel() {
             ))}
           </div>
 
-          {/* Add breakpoint form */}
           {enabled && (
-            <div className="mt-2 flex flex-col gap-1.5">
+            <div className="p-2 border-t border-border-1 space-y-1.5">
+              <div className="text-[10px] text-text-3 uppercase tracking-wide font-medium">
+                Manual breakpoint
+              </div>
+              <input
+                type="text"
+                value={bpUrl}
+                onChange={(e) => setBpUrl(e.target.value)}
+                placeholder="Script URL"
+                className="w-full h-6 px-2 rounded bg-surface-0 border border-border-1 text-[10px] text-text-1 font-mono placeholder:text-text-3 focus:outline-none focus:border-accent"
+              />
               <div className="flex items-center gap-1.5">
-                <input
-                  type="text"
-                  value={bpUrl}
-                  onChange={(e) => setBpUrl(e.target.value)}
-                  placeholder="Script URL"
-                  className="flex-1 h-6 px-2 rounded bg-surface-0 border border-border-1 text-[10px] text-text-1 font-mono placeholder:text-text-3 focus:outline-none focus:border-accent"
-                />
                 <input
                   type="text"
                   value={bpLine}
                   onChange={(e) => setBpLine(e.target.value)}
                   placeholder="Line"
-                  className="w-14 h-6 px-2 rounded bg-surface-0 border border-border-1 text-[10px] text-text-1 font-mono placeholder:text-text-3 focus:outline-none focus:border-accent"
+                  className="w-16 h-6 px-2 rounded bg-surface-0 border border-border-1 text-[10px] text-text-1 font-mono placeholder:text-text-3 focus:outline-none focus:border-accent"
                 />
-              </div>
-              <div className="flex items-center gap-1.5">
                 <input
                   type="text"
                   value={bpCondition}
                   onChange={(e) => setBpCondition(e.target.value)}
-                  placeholder="Condition (optional)"
+                  placeholder="Condition"
                   className="flex-1 h-6 px-2 rounded bg-surface-0 border border-border-1 text-[10px] text-text-1 font-mono placeholder:text-text-3 focus:outline-none focus:border-accent"
                 />
                 <button
@@ -286,7 +738,32 @@ export function DebuggerPanel() {
               </div>
             </div>
           )}
-        </div>
+
+          {pausedState?.paused && pausedState.callFrames.length > 0 && (
+            <div className="border-t border-border-1">
+              <div className="px-2 py-1.5 border-b border-border-1 bg-surface-0">
+                <span className="text-[10px] text-text-3 uppercase tracking-wide font-medium">
+                  Call Stack
+                </span>
+              </div>
+              <div className="p-2 space-y-0.5">
+                {pausedState.callFrames.map((frame) => (
+                  <div
+                    key={frame.id}
+                    className="flex flex-col gap-0.5 text-[10px] font-mono text-text-2 py-1 border-b border-border-1/50 last:border-b-0"
+                  >
+                    <span className="text-accent truncate">
+                      {frame.functionName || '(anonymous)'}
+                    </span>
+                    <span className="text-text-3 truncate">
+                      {frame.url || frame.scriptId || 'anonymous'}:{frame.lineNumber + 1}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </aside>
       </div>
     </div>
   )

--- a/frontend/src/lib/browser-debug-api.ts
+++ b/frontend/src/lib/browser-debug-api.ts
@@ -33,6 +33,7 @@ export interface ConsoleEntry {
 export interface BreakpointInfo {
   id: string
   scriptUrl: string
+  scriptId?: string
   lineNumber: number
   columnNumber: number
   condition?: string
@@ -42,6 +43,7 @@ export interface CallFrame {
   id: string
   functionName: string
   url: string
+  scriptId: string
   lineNumber: number
   columnNumber: number
 }
@@ -51,7 +53,30 @@ export interface PausedState {
   reason: string
   callFrames: CallFrame[]
   scriptUrl: string
+  scriptId: string
   lineNumber: number
+}
+
+export interface ScriptInfo {
+  scriptId: string
+  url: string
+  startLine: number
+  endLine: number
+  executionContextId: number
+  hash: string
+}
+
+export interface SourceFileInfo {
+  id: string
+  url: string
+  type: string
+  mimeType: string
+  scriptId?: string
+  frameId?: string
+  startLine: number
+  endLine: number
+  canSetBreakpoint: boolean
+  fromDebugger: boolean
 }
 
 export interface DOMNode {
@@ -59,9 +84,17 @@ export interface DOMNode {
   nodeType: number
   nodeName: string
   localName: string
+  nodeValue: string
   attributes: string[]
   childCount: number
   children?: DOMNode[]
+}
+
+export type DOMBreakpointType = 'subtree-modified' | 'attribute-modified' | 'node-removed'
+
+export interface DOMBreakpointInfo {
+  nodeId: number
+  type: DOMBreakpointType
 }
 
 export interface CookieEntry {
@@ -115,8 +148,14 @@ declare global {
       EnableDebugger: () => Promise<void>
       DisableDebugger: () => Promise<void>
       SetBreakpoint: (url: string, line: number, condition: string) => Promise<string>
+      SetBreakpointByScriptID: (scriptId: string, line: number, column: number, condition: string) => Promise<string>
       RemoveBreakpoint: (breakpointId: string) => Promise<void>
       GetBreakpoints: () => Promise<BreakpointInfo[]>
+      GetScripts: () => Promise<ScriptInfo[]>
+      GetScriptSource: (scriptId: string) => Promise<string>
+      GetSourceFiles: () => Promise<SourceFileInfo[]>
+      GetSourceFileContent: (sourceId: string) => Promise<string>
+      ReloadPageNoCache: () => Promise<void>
       Resume: () => Promise<void>
       StepOver: () => Promise<void>
       StepInto: () => Promise<void>
@@ -127,10 +166,14 @@ declare global {
       EnableDOM: () => Promise<void>
       GetDocument: (depth: number) => Promise<DOMNode>
       GetNodeHTML: (nodeId: number) => Promise<string>
+      GetPageSource: () => Promise<string>
       QuerySelector: (selector: string) => Promise<DOMNode>
       GetComputedStyle: (nodeId: number) => Promise<Record<string, string>>
       HighlightNode: (nodeId: number) => Promise<void>
       HideHighlight: () => Promise<void>
+      SetDOMBreakpoint: (nodeId: number, breakpointType: DOMBreakpointType) => Promise<void>
+      RemoveDOMBreakpoint: (nodeId: number, breakpointType: DOMBreakpointType) => Promise<void>
+      GetDOMBreakpoints: () => Promise<DOMBreakpointInfo[]>
 
       // Storage
       GetCookies: () => Promise<CookieEntry[]>
@@ -368,6 +411,21 @@ export async function setBreakpoint(
   }
 }
 
+export async function setBreakpointByScriptID(
+  scriptId: string,
+  line: number,
+  column: number,
+  condition: string
+): Promise<string> {
+  try {
+    const binding = getBrowserDebugBinding()
+    if (!binding?.SetBreakpointByScriptID) return ''
+    return await binding.SetBreakpointByScriptID(scriptId, line, column, condition)
+  } catch {
+    return ''
+  }
+}
+
 export async function removeBreakpoint(breakpointId: string): Promise<void> {
   try {
     const binding = getBrowserDebugBinding()
@@ -385,6 +443,56 @@ export async function getBreakpoints(): Promise<BreakpointInfo[]> {
     return await binding.GetBreakpoints()
   } catch {
     return []
+  }
+}
+
+export async function getScripts(): Promise<ScriptInfo[]> {
+  try {
+    const binding = getBrowserDebugBinding()
+    if (!binding?.GetScripts) return []
+    return await binding.GetScripts()
+  } catch {
+    return []
+  }
+}
+
+export async function getScriptSource(scriptId: string): Promise<string> {
+  try {
+    const binding = getBrowserDebugBinding()
+    if (!binding?.GetScriptSource) return ''
+    return await binding.GetScriptSource(scriptId)
+  } catch {
+    return ''
+  }
+}
+
+export async function getSourceFiles(): Promise<SourceFileInfo[]> {
+  try {
+    const binding = getBrowserDebugBinding()
+    if (!binding?.GetSourceFiles) return []
+    return await binding.GetSourceFiles()
+  } catch {
+    return []
+  }
+}
+
+export async function getSourceFileContent(sourceId: string): Promise<string> {
+  try {
+    const binding = getBrowserDebugBinding()
+    if (!binding?.GetSourceFileContent) return ''
+    return await binding.GetSourceFileContent(sourceId)
+  } catch {
+    return ''
+  }
+}
+
+export async function reloadPageNoCache(): Promise<void> {
+  try {
+    const binding = getBrowserDebugBinding()
+    if (!binding?.ReloadPageNoCache) return
+    await binding.ReloadPageNoCache()
+  } catch {
+    // silently ignore
   }
 }
 
@@ -432,11 +540,11 @@ export async function getPausedState(): Promise<PausedState> {
   try {
     const binding = getBrowserDebugBinding()
     if (!binding) {
-      return { paused: false, reason: '', callFrames: [], scriptUrl: '', lineNumber: 0 }
+      return { paused: false, reason: '', callFrames: [], scriptUrl: '', scriptId: '', lineNumber: 0 }
     }
     return await binding.GetPausedState()
   } catch {
-    return { paused: false, reason: '', callFrames: [], scriptUrl: '', lineNumber: 0 }
+    return { paused: false, reason: '', callFrames: [], scriptUrl: '', scriptId: '', lineNumber: 0 }
   }
 }
 
@@ -467,6 +575,16 @@ export async function getNodeHTML(nodeId: number): Promise<string> {
     const binding = getBrowserDebugBinding()
     if (!binding) return ''
     return await binding.GetNodeHTML(nodeId)
+  } catch {
+    return ''
+  }
+}
+
+export async function getPageSource(): Promise<string> {
+  try {
+    const binding = getBrowserDebugBinding()
+    if (!binding?.GetPageSource) return ''
+    return await binding.GetPageSource()
   } catch {
     return ''
   }
@@ -511,6 +629,42 @@ export async function hideHighlight(): Promise<void> {
     await binding.HideHighlight()
   } catch {
     // silently ignore
+  }
+}
+
+export async function setDOMBreakpoint(
+  nodeId: number,
+  breakpointType: DOMBreakpointType
+): Promise<void> {
+  try {
+    const binding = getBrowserDebugBinding()
+    if (!binding?.SetDOMBreakpoint) return
+    await binding.SetDOMBreakpoint(nodeId, breakpointType)
+  } catch {
+    // silently ignore
+  }
+}
+
+export async function removeDOMBreakpoint(
+  nodeId: number,
+  breakpointType: DOMBreakpointType
+): Promise<void> {
+  try {
+    const binding = getBrowserDebugBinding()
+    if (!binding?.RemoveDOMBreakpoint) return
+    await binding.RemoveDOMBreakpoint(nodeId, breakpointType)
+  } catch {
+    // silently ignore
+  }
+}
+
+export async function getDOMBreakpoints(): Promise<DOMBreakpointInfo[]> {
+  try {
+    const binding = getBrowserDebugBinding()
+    if (!binding?.GetDOMBreakpoints) return []
+    return await binding.GetDOMBreakpoints()
+  } catch {
+    return []
   }
 }
 

--- a/frontend/wailsjs/go/main/BrowserDebug.d.ts
+++ b/frontend/wailsjs/go/main/BrowserDebug.d.ts
@@ -44,6 +44,8 @@ export function GetConsoleLogs():Promise<Array<main.ConsoleEntry>>;
 
 export function GetCookies():Promise<Array<main.CookieEntry>>;
 
+export function GetDOMBreakpoints():Promise<Array<main.DOMBreakpointInfo>>;
+
 export function GetDebugStatus():Promise<main.DebugStatus>;
 
 export function GetDocument(arg1:number):Promise<main.DOMNode>;
@@ -64,7 +66,15 @@ export function GetRequestBody(arg1:string):Promise<string>;
 
 export function GetResponseBody(arg1:string):Promise<string>;
 
+export function GetScriptSource(arg1:string):Promise<string>;
+
+export function GetScripts():Promise<Array<main.ScriptInfo>>;
+
 export function GetSessionStorage():Promise<Array<main.StorageItem>>;
+
+export function GetSourceFileContent(arg1:string):Promise<string>;
+
+export function GetSourceFiles():Promise<Array<main.SourceFileInfo>>;
 
 export function GetTargetInfo():Promise<Record<string, any>>;
 
@@ -94,11 +104,19 @@ export function NavigateTarget(arg1:string):Promise<void>;
 
 export function QuerySelector(arg1:string):Promise<main.DOMNode>;
 
+export function ReloadPageNoCache():Promise<void>;
+
 export function RemoveBreakpoint(arg1:string):Promise<void>;
+
+export function RemoveDOMBreakpoint(arg1:number,arg2:string):Promise<void>;
 
 export function Resume():Promise<void>;
 
 export function SetBreakpoint(arg1:string,arg2:number,arg3:string):Promise<string>;
+
+export function SetBreakpointByScriptID(arg1:string,arg2:number,arg3:number,arg4:string):Promise<string>;
+
+export function SetDOMBreakpoint(arg1:number,arg2:string):Promise<void>;
 
 export function SetThrottling(arg1:number,arg2:number,arg3:number):Promise<void>;
 

--- a/frontend/wailsjs/go/main/BrowserDebug.js
+++ b/frontend/wailsjs/go/main/BrowserDebug.js
@@ -86,6 +86,10 @@ export function GetCookies() {
   return window['go']['main']['BrowserDebug']['GetCookies']();
 }
 
+export function GetDOMBreakpoints() {
+  return window['go']['main']['BrowserDebug']['GetDOMBreakpoints']();
+}
+
 export function GetDebugStatus() {
   return window['go']['main']['BrowserDebug']['GetDebugStatus']();
 }
@@ -126,8 +130,24 @@ export function GetResponseBody(arg1) {
   return window['go']['main']['BrowserDebug']['GetResponseBody'](arg1);
 }
 
+export function GetScriptSource(arg1) {
+  return window['go']['main']['BrowserDebug']['GetScriptSource'](arg1);
+}
+
+export function GetScripts() {
+  return window['go']['main']['BrowserDebug']['GetScripts']();
+}
+
 export function GetSessionStorage() {
   return window['go']['main']['BrowserDebug']['GetSessionStorage']();
+}
+
+export function GetSourceFileContent(arg1) {
+  return window['go']['main']['BrowserDebug']['GetSourceFileContent'](arg1);
+}
+
+export function GetSourceFiles() {
+  return window['go']['main']['BrowserDebug']['GetSourceFiles']();
 }
 
 export function GetTargetInfo() {
@@ -186,8 +206,16 @@ export function QuerySelector(arg1) {
   return window['go']['main']['BrowserDebug']['QuerySelector'](arg1);
 }
 
+export function ReloadPageNoCache() {
+  return window['go']['main']['BrowserDebug']['ReloadPageNoCache']();
+}
+
 export function RemoveBreakpoint(arg1) {
   return window['go']['main']['BrowserDebug']['RemoveBreakpoint'](arg1);
+}
+
+export function RemoveDOMBreakpoint(arg1, arg2) {
+  return window['go']['main']['BrowserDebug']['RemoveDOMBreakpoint'](arg1, arg2);
 }
 
 export function Resume() {
@@ -196,6 +224,14 @@ export function Resume() {
 
 export function SetBreakpoint(arg1, arg2, arg3) {
   return window['go']['main']['BrowserDebug']['SetBreakpoint'](arg1, arg2, arg3);
+}
+
+export function SetBreakpointByScriptID(arg1, arg2, arg3, arg4) {
+  return window['go']['main']['BrowserDebug']['SetBreakpointByScriptID'](arg1, arg2, arg3, arg4);
+}
+
+export function SetDOMBreakpoint(arg1, arg2) {
+  return window['go']['main']['BrowserDebug']['SetDOMBreakpoint'](arg1, arg2);
 }
 
 export function SetThrottling(arg1, arg2, arg3) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -15,6 +15,7 @@ export namespace main {
 	export class BreakpointInfo {
 	    id: string;
 	    scriptUrl: string;
+	    scriptId?: string;
 	    lineNumber: number;
 	    columnNumber: number;
 	    condition?: string;
@@ -27,6 +28,7 @@ export namespace main {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.id = source["id"];
 	        this.scriptUrl = source["scriptUrl"];
+	        this.scriptId = source["scriptId"];
 	        this.lineNumber = source["lineNumber"];
 	        this.columnNumber = source["columnNumber"];
 	        this.condition = source["condition"];
@@ -36,6 +38,7 @@ export namespace main {
 	    id: string;
 	    functionName: string;
 	    url: string;
+	    scriptId: string;
 	    lineNumber: number;
 	    columnNumber: number;
 	
@@ -48,6 +51,7 @@ export namespace main {
 	        this.id = source["id"];
 	        this.functionName = source["functionName"];
 	        this.url = source["url"];
+	        this.scriptId = source["scriptId"];
 	        this.lineNumber = source["lineNumber"];
 	        this.columnNumber = source["columnNumber"];
 	    }
@@ -144,11 +148,26 @@ export namespace main {
 	        this.sameSite = source["sameSite"];
 	    }
 	}
+export class DOMBreakpointInfo {
+    nodeId: number;
+    type: string;
+
+    static createFrom(source: any = {}) {
+        return new DOMBreakpointInfo(source);
+    }
+
+    constructor(source: any = {}) {
+        if ('string' === typeof source) source = JSON.parse(source);
+        this.nodeId = source["nodeId"];
+	        this.type = source["type"];
+	    }
+	}
 	export class DOMNode {
 	    nodeId: number;
 	    nodeType: number;
 	    nodeName: string;
 	    localName: string;
+	    nodeValue: string;
 	    attributes: string[];
 	    childCount: number;
 	    children?: DOMNode[];
@@ -163,6 +182,7 @@ export namespace main {
 	        this.nodeType = source["nodeType"];
 	        this.nodeName = source["nodeName"];
 	        this.localName = source["localName"];
+	        this.nodeValue = source["nodeValue"];
 	        this.attributes = source["attributes"];
 	        this.childCount = source["childCount"];
 	        this.children = this.convertValues(source["children"], DOMNode);
@@ -491,6 +511,7 @@ export namespace main {
 	    reason: string;
 	    callFrames: CallFrame[];
 	    scriptUrl: string;
+	    scriptId: string;
 	    lineNumber: number;
 	
 	    static createFrom(source: any = {}) {
@@ -503,6 +524,7 @@ export namespace main {
 	        this.reason = source["reason"];
 	        this.callFrames = this.convertValues(source["callFrames"], CallFrame);
 	        this.scriptUrl = source["scriptUrl"];
+	        this.scriptId = source["scriptId"];
 	        this.lineNumber = source["lineNumber"];
 	    }
 	
@@ -776,6 +798,58 @@ export namespace main {
 	        this.venvReady = source["venvReady"];
 	    }
 	}
+export class ScriptInfo {
+    scriptId: string;
+    url: string;
+    startLine: number;
+    endLine: number;
+    executionContextId: number;
+    hash: string;
+
+    static createFrom(source: any = {}) {
+        return new ScriptInfo(source);
+    }
+
+    constructor(source: any = {}) {
+        if ('string' === typeof source) source = JSON.parse(source);
+        this.scriptId = source["scriptId"];
+	        this.url = source["url"];
+	        this.startLine = source["startLine"];
+	        this.endLine = source["endLine"];
+	        this.executionContextId = source["executionContextId"];
+	        this.hash = source["hash"];
+	    }
+	}
+	export class SourceFileInfo {
+	    id: string;
+	    url: string;
+	    type: string;
+	    mimeType: string;
+	    scriptId?: string;
+	    frameId?: string;
+    startLine: number;
+    endLine: number;
+    canSetBreakpoint: boolean;
+    fromDebugger: boolean;
+
+    static createFrom(source: any = {}) {
+        return new SourceFileInfo(source);
+    }
+
+    constructor(source: any = {}) {
+        if ('string' === typeof source) source = JSON.parse(source);
+        this.id = source["id"];
+	        this.url = source["url"];
+	        this.type = source["type"];
+	        this.mimeType = source["mimeType"];
+	        this.scriptId = source["scriptId"];
+	        this.frameId = source["frameId"];
+	        this.startLine = source["startLine"];
+	        this.endLine = source["endLine"];
+	        this.canSetBreakpoint = source["canSetBreakpoint"];
+	        this.fromDebugger = source["fromDebugger"];
+	    }
+	}
 	export class StorageEntry {
 	    bucket: string;
 	    key: string;
@@ -981,4 +1055,3 @@ export namespace main {
 	}
 
 }
-


### PR DESCRIPTION
## Summary

  Improve the integrated Browser Debug workflow with a more complete Sources and DOM debugging experience.

  Changes include:
  - combined CDP scripts and page resources in the debugger source list
  - current paused line highlighting, closer to Chrome DevTools behavior
  - lightweight syntax highlighting for JS, HTML, and CSS source views
  - DOM source view, DOM breakpoints, and clearer non-rendered DOM nodes
  - no-cache debugger refresh to avoid stale JS/resources after reload
<img width="1398" height="898" alt="debug_bw" src="https://github.com/user-attachments/assets/2b5639f6-d8ed-4260-b025-512a1f10c2ae" />

  ## Product Impact

  Developers can inspect and debug browser pages inside adOmnia with less tool switching. The debugger now makes the active execution line visible, exposes more
  complete source files, and avoids stale cached scripts after refresh.

  ## Type

  - [x] Bug fix
  - [x] Feature
  - [x] UI/UX polish
  - [x] Documentation
  - [ ] Build/release
  - [ ] Refactor
  - [ ] Security/privacy

  ## Verification

  - [x] `cd frontend && npm run build`
  - [x] `go test ./...`
  - [ ] Manual smoke test performed
  - [ ] Not applicable

  Manual test notes:
  `wails build` regenerated bindings.

  ## Risk

  - [ ] Low: isolated change
  - [x] Medium: shared UI/state/build behavior
  - [ ] High: storage, workspace format, security, release pipeline, or network behavior

  ## Checklist

  - [x] The change preserves local-first behavior.
  - [x] User-facing behavior is documented.
  - [ ] Screenshots are included for visible UI changes.
  - [ ] `CHANGELOG.md` is updated under `[Unreleased]` if release-worthy.
  - [x] Secrets, tokens, cookies, and private URLs are not included in logs/screenshots.

  ## Related Issues

  Fixes #
