### PR TITLE
Start adOmnia on a clean hub instead of auto-loading demo data, guide…

### DIFF
--- a/frontend/src/components/collections/CollectionTree.tsx
+++ b/frontend/src/components/collections/CollectionTree.tsx
@@ -12,6 +12,7 @@ import {
   Search,
   Trash2,
   Upload,
+  UploadCloud,
   X,
 } from 'lucide-react'
 import type { Collection, FolderItem, HttpMethod, RequestItem, TreeNode } from '@/lib/types'
@@ -323,7 +324,7 @@ function TreeNodeRow({
         }}
         className={cn(
           'group relative flex h-7 items-center gap-1 rounded px-1 text-xs transition-colors',
-          activeRequestId === node.id ? 'bg-accent/10 text-text-1' : 'text-text-2 hover:bg-surface-2',
+          activeRequestId === node.id ? 'bg-surface-2 text-text-1 shadow-[inset_2px_0_0_var(--color-accent)]' : 'text-text-2 hover:bg-surface-2/70',
           target === 'inside' && !isInvalidDrop && 'ring-1 ring-accent/70 bg-accent/10',
           isInvalidDrop && target && 'ring-1 ring-error/60 bg-error/8',
           focusedId === node.id && 'ring-1 ring-inset ring-accent/50',
@@ -336,7 +337,7 @@ function TreeNodeRow({
         {isFolder ? (
           <>
             <ChevronRight size={12} className={cn('shrink-0 text-text-4 transition-transform', isOpen && 'rotate-90')} />
-            <Folder size={13} className="shrink-0 text-accent" />
+            <Folder size={13} className="shrink-0 text-text-3" />
           </>
         ) : (
           <span className={cn('w-9 shrink-0 text-[9px] font-bold', METHOD_COLORS[(node as RequestItem).method] ?? 'text-text-3')}>{(node as RequestItem).method}</span>
@@ -650,7 +651,7 @@ export function CollectionTree({
   return (
     <div className="relative flex h-full flex-col">
       <div className="flex items-center gap-1 border-b border-border-1 px-2 py-2">
-        <span className="flex-1 text-[10px] font-semibold uppercase tracking-wider text-text-3">Collections</span>
+        <span className="flex-1 text-[10px] font-semibold uppercase tracking-wider text-text-4">Collections</span>
         <input ref={fileInputRef} type="file" accept=".json,.yaml,.yml,.bru" className="hidden" onChange={(event) => void handleImport(event.target.files?.[0])} />
         <button onClick={() => fileInputRef.current?.click()} title="Import Postman, Insomnia, Bruno, adOmnia or OpenAPI" className="grid h-6 w-6 place-items-center rounded text-text-3 hover:bg-surface-2 hover:text-text-1">
           <Upload size={14} />
@@ -675,9 +676,21 @@ export function CollectionTree({
 
       <div className="flex-1 overflow-y-auto px-1 pb-2 outline-none" tabIndex={0} onKeyDown={handleTreeKeyDown}>
         {filtered.length === 0 ? (
-          <div className="flex flex-col items-center gap-2 px-4 py-8 text-center">
-            <p className="text-xs text-text-4">No collections yet</p>
-            <button onClick={onAddCollection} className="text-xs text-accent hover:text-accent-light">Create collection</button>
+          <div className="flex flex-col items-center gap-3 px-4 py-8 text-center">
+            <div className="grid h-10 w-10 place-items-center rounded-lg border border-dashed border-border-2 bg-surface-1 text-text-3">
+              <UploadCloud size={18} />
+            </div>
+            <div>
+              <p className="text-xs font-medium text-text-3">No collections yet</p>
+              <p className="mt-1 text-[10px] leading-relaxed text-text-4">
+                Drop Postman, OpenAPI, Insomnia, Bruno, .adomnia or HAR files anywhere in adOmnia.
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <button onClick={() => fileInputRef.current?.click()} className="text-xs text-accent hover:text-accent-light">Import file</button>
+              <span className="text-text-4">/</span>
+              <button onClick={onAddCollection} className="text-xs text-accent hover:text-accent-light">Create collection</button>
+            </div>
           </div>
         ) : filtered.map((collection, collectionIndex) => (
           <div
@@ -700,7 +713,7 @@ export function CollectionTree({
                 setContext({ kind: 'collection', collection, x: event.clientX, y: event.clientY })
               }}
               className={cn(
-                'group relative flex h-7 cursor-pointer items-center gap-1 rounded px-1 text-xs font-medium text-text-1 hover:bg-surface-2',
+                'group relative flex h-7 cursor-pointer items-center gap-1 rounded px-1 text-xs font-medium text-text-2 hover:bg-surface-2/70 hover:text-text-1',
                 dropTarget?.id === collection.id && dragPayload?.type === 'node' && 'ring-1 ring-accent/70 bg-accent/10',
                 focusedId === collection.id && 'ring-1 ring-inset ring-accent/50',
               )}
@@ -708,7 +721,7 @@ export function CollectionTree({
               {collection.color && <span className="absolute bottom-0.5 left-0 top-0.5 w-[2px] rounded-r" style={{ backgroundColor: collection.color }} />}
               <GripVertical size={11} className="shrink-0 cursor-grab text-text-4 opacity-0 group-hover:opacity-60" />
               <ChevronRight size={12} className={cn('shrink-0 text-text-4 transition-transform', openIds.has(collection.id) && 'rotate-90')} />
-              <Folder size={13} className="shrink-0 text-accent" style={collection.color ? { color: collection.color } : undefined} />
+              <Folder size={13} className="shrink-0 text-text-3" style={collection.color ? { color: collection.color } : undefined} />
               {editingId === collection.id ? (
                 <InlineEdit value={collection.name} onCommit={(name) => { onRenameCollection(collection.id, name); setEditingId(null) }} onCancel={() => setEditingId(null)} />
               ) : (

--- a/frontend/src/components/composer/Composer.tsx
+++ b/frontend/src/components/composer/Composer.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useMemo } from 'react'
-import { Send, Save, FileCode, Gauge, X, Plus, Check, CornerDownRight, Clock, Code, Copy, CheckCheck, FileText } from 'lucide-react'
-import type { RequestItem, HttpMethod } from '@/lib/types'
+import { Send, Save, FileCode, Gauge, X, Plus, Check, CornerDownRight, Clock, Code, Copy, CheckCheck, FileText, Circle, ListChecks, ShieldCheck } from 'lucide-react'
+import type { RequestItem, HttpMethod, KVRow } from '@/lib/types'
 import { uid, blankBody, blankAuth } from '@/lib/types'
 import { cn } from '@/lib/utils'
 import { KVEditor } from './KVEditor'
@@ -243,6 +243,160 @@ function CookieJarSection({ requestUrl }: { requestUrl: string }) {
   )
 }
 
+function enabledRows(rows: KVRow[] | undefined): KVRow[] {
+  return (rows ?? []).filter((row) => row.enabled && row.key.trim())
+}
+
+function requestVariables(request: RequestItem): string[] {
+  const values = [
+    request.url,
+    request.description ?? '',
+    ...(request.headers ?? []).flatMap((row) => [row.key, row.value]),
+    ...(request.params ?? []).flatMap((row) => [row.key, row.value]),
+    ...(request.cookies ?? []).flatMap((row) => [row.key, row.value]),
+    ...(request.bodies ?? []).flatMap((body) => [body.raw, body.graphqlVariables ?? '', ...(body.form ?? []).flatMap((row) => [row.key, row.value])]),
+  ]
+  const names = new Set<string>()
+  for (const value of values) {
+    for (const match of String(value ?? '').matchAll(/\{\{\s*([^}\s]+)\s*\}\}/g)) {
+      names.add(match[1])
+    }
+  }
+  return [...names].sort((a, b) => a.localeCompare(b))
+}
+
+function hostFromUrl(url: string): string {
+  try { return new URL(url).host } catch { return 'No host yet' }
+}
+
+function RequestOverview({
+  request,
+  vars,
+  hasActiveEnv,
+  onChange,
+  onOpenSection,
+}: {
+  request: RequestItem
+  vars: Record<string, string>
+  hasActiveEnv: boolean
+  onChange: (request: RequestItem) => void
+  onOpenSection: (section: ComposerSection) => void
+}) {
+  const variables = requestVariables(request)
+  const unresolved = variables.filter((name) => vars[name] === undefined)
+  const headers = enabledRows(request.headers)
+  const params = enabledRows(request.params)
+  const cookies = enabledRows(request.cookies)
+  const activeBody = request.bodies?.[request.activeBodyIdx ?? 0]
+  const hasBody = Boolean(activeBody && activeBody.type !== 'none')
+  const docsFilled = Boolean(request.description?.trim())
+  const authLabel = request.auth?.type && request.auth.type !== 'none' ? request.auth.type.toUpperCase() : 'No auth'
+  const setupItems = [
+    { label: 'URL is ready', ok: Boolean(request.url.trim()), section: null },
+    { label: variables.length ? `${variables.length} variable${variables.length === 1 ? '' : 's'} detected` : 'No variables needed', ok: unresolved.length === 0, section: 'params' as ComposerSection | null },
+    { label: request.auth?.type && request.auth.type !== 'none' ? `${authLabel} configured` : 'Auth intentionally empty', ok: true, section: 'auth' as ComposerSection | null },
+    { label: docsFilled ? 'Documentation present' : 'Add request notes', ok: docsFilled, section: 'notes' as ComposerSection | null },
+  ]
+
+  return (
+    <div className="flex flex-col gap-4 p-5">
+      <section className="border-b border-border-1 pb-4">
+        <div className="mb-2 flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.12em] text-text-4">
+          <span className={cn('font-bold', METHOD_COLORS[request.method] ?? 'text-text-2')}>{request.method}</span>
+          <span>{hostFromUrl(request.url)}</span>
+        </div>
+        <input
+          value={request.name}
+          onChange={(event) => onChange({ ...request, name: event.target.value })}
+          placeholder="Request title"
+          className="w-full bg-transparent text-[26px] font-semibold leading-tight text-text-1 outline-none placeholder:text-text-4"
+        />
+        <textarea
+          value={request.description ?? ''}
+          onChange={(event) => onChange({ ...request, description: event.target.value })}
+          placeholder="Add a clear description: what this request does, when to use it, required setup, examples or edge cases..."
+          className="mt-3 min-h-20 w-full resize-y rounded border border-border-2 bg-surface-1 px-3 py-2 text-xs leading-relaxed text-text-2 outline-none placeholder:text-text-4 focus:border-accent"
+        />
+      </section>
+
+      <section className="grid gap-3 xl:grid-cols-[minmax(0,1fr)_300px]">
+        <div className="rounded-lg border border-border-1 bg-surface-1">
+          <div className="flex items-center gap-2 border-b border-border-1 px-3 py-2">
+            <ListChecks size={13} className="text-accent" />
+            <h3 className="text-xs font-semibold text-text-1">Setup</h3>
+          </div>
+          <div className="divide-y divide-border-1">
+            {setupItems.map((item) => (
+              <button
+                key={item.label}
+                onClick={() => item.section && onOpenSection(item.section)}
+                className="flex w-full items-center gap-3 px-3 py-2.5 text-left text-xs text-text-2 transition-colors hover:bg-surface-2"
+              >
+                {item.ok ? <Check size={13} className="text-success" /> : <Circle size={13} className="text-warning" />}
+                <span className="flex-1">{item.label}</span>
+                {item.section && <span className="font-mono text-[10px] text-text-4">open</span>}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-border-1 bg-surface-1">
+          <div className="flex items-center gap-2 border-b border-border-1 px-3 py-2">
+            <ShieldCheck size={13} className="text-accent" />
+            <h3 className="text-xs font-semibold text-text-1">Request context</h3>
+          </div>
+          <dl className="grid grid-cols-[92px_1fr] gap-x-3 gap-y-2 px-3 py-3 font-mono text-[10px]">
+            <dt className="text-text-4">Auth</dt><dd className="truncate text-text-2">{authLabel}</dd>
+            <dt className="text-text-4">Headers</dt><dd className="text-text-2">{headers.length}</dd>
+            <dt className="text-text-4">Params</dt><dd className="text-text-2">{params.length}</dd>
+            <dt className="text-text-4">Cookies</dt><dd className="text-text-2">{cookies.length}</dd>
+            <dt className="text-text-4">Body</dt><dd className="text-text-2">{hasBody ? activeBody?.type : 'none'}</dd>
+            <dt className="text-text-4">Tests</dt><dd className="text-text-2">{request.assertions?.length ?? 0}</dd>
+          </dl>
+        </div>
+      </section>
+
+      {variables.length > 0 && (
+        <section className="rounded-lg border border-border-1 bg-surface-1">
+          <div className="flex items-center justify-between gap-2 border-b border-border-1 px-3 py-2">
+            <h3 className="text-xs font-semibold text-text-1">Variables</h3>
+            <span className="font-mono text-[10px] text-text-4">{hasActiveEnv ? `${unresolved.length} unresolved` : 'No environment selected'}</span>
+          </div>
+          <div className="grid grid-cols-1 gap-2 p-3 md:grid-cols-2">
+            {variables.map((name) => {
+              const resolved = vars[name]
+              return (
+                <div key={name} className="flex min-w-0 items-center gap-2 rounded border border-border-2 bg-surface-2 px-2 py-1.5 font-mono text-[10px]">
+                  <span className={cn('h-1.5 w-1.5 shrink-0 rounded-full', resolved === undefined ? 'bg-warning' : 'bg-success')} />
+                  <span className="truncate text-accent">{`{{${name}}}`}</span>
+                  <span className="min-w-0 flex-1 truncate text-right text-text-4">{resolved === undefined ? 'unresolved' : resolved}</span>
+                </div>
+              )
+            })}
+          </div>
+        </section>
+      )}
+
+      <section className="grid gap-2 sm:grid-cols-4">
+        {([
+          { label: 'Auth', section: 'auth' },
+          { label: 'Headers', section: 'headers' },
+          { label: 'Body', section: 'body' },
+          { label: 'Tests', section: 'tests' },
+        ] satisfies Array<{ label: string; section: ComposerSection }>).map(({ label, section }) => (
+          <button
+            key={section}
+            onClick={() => onOpenSection(section)}
+            className="rounded-lg border border-border-2 bg-surface-1 px-3 py-2 text-left text-xs text-text-2 transition-colors hover:border-accent/30 hover:bg-surface-2 hover:text-text-1"
+          >
+            {label}
+          </button>
+        ))}
+      </section>
+    </div>
+  )
+}
+
 export function Composer({ tabId, request, onChange, onSend, onSave, onLoadTest, loading, hideRequestBar = false }: ComposerProps) {
   const getResolvedVars = useEnvironmentsStore((s) => s.getResolvedVars)
   const activeEnvId = useEnvironmentsStore((s) => s.activeEnvId)
@@ -290,6 +444,7 @@ export function Composer({ tabId, request, onChange, onSend, onSave, onLoadTest,
   }, [cookieJarEntries, request.url, sendCookiesAutomatically])
 
   const tabs = [
+    { id: 'overview' as ComposerSection, label: 'Overview', count: request.description?.trim() ? 1 : 0 },
     { id: 'body' as ComposerSection, label: 'Body', count: bodyCount },
     { id: 'auth' as ComposerSection, label: 'Auth', count: request.auth?.type !== 'none' ? 1 : 0 },
     { id: 'headers' as ComposerSection, label: 'Headers', count: (request.headers ?? []).filter((h) => h.enabled && h.key).length },
@@ -308,6 +463,11 @@ export function Composer({ tabId, request, onChange, onSend, onSave, onLoadTest,
   const handleCurlImport = (curlStr: string) => {
     const parsed = parseCurl(curlStr)
     if (parsed) onChange(applyParsedCurl(parsed, request))
+  }
+
+  const openSection = (section: ComposerSection) => {
+    setActiveTab(section)
+    updateViewState(tabId, { composerSection: section })
   }
 
   useEffect(() => {
@@ -490,6 +650,15 @@ export function Composer({ tabId, request, onChange, onSend, onSave, onLoadTest,
           }}
           className="flex-1 min-h-0 overflow-y-auto flex flex-col"
         >
+          {activeTab === 'overview' && (
+            <RequestOverview
+              request={request}
+              vars={resolvedVars}
+              hasActiveEnv={hasActiveEnv}
+              onChange={onChange}
+              onOpenSection={openSection}
+            />
+          )}
           {activeTab === 'params' && (
             <KVEditor rows={request.params ?? []} onChange={(params) => onChange({ ...request, params })} />
           )}

--- a/frontend/src/components/layout/DropOverlay.tsx
+++ b/frontend/src/components/layout/DropOverlay.tsx
@@ -6,7 +6,7 @@ export function DropOverlay() {
       <div className="flex flex-col items-center gap-3 rounded-lg border-2 border-dashed border-accent bg-surface-1 p-8 shadow-2xl">
         <UploadCloud size={48} strokeWidth={1.5} className="text-accent" />
         <p className="text-sm font-semibold text-text-1">Drop a file to open it</p>
-        <p className="text-[10px] text-text-3">Collections / HAR / WSDL / Java Class</p>
+        <p className="text-[10px] text-text-3">Postman / OpenAPI / Insomnia / HAR / WSDL / Java Class</p>
       </div>
     </div>
   )

--- a/frontend/src/components/layout/MainArea.tsx
+++ b/frontend/src/components/layout/MainArea.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef, Suspense } from 'react'
-import { ArrowLeft, Check, Clock, CornerDownRight, Gauge, Save, Send, X } from 'lucide-react'
+import { ArrowLeft, Check, ChevronRight, Clock, CornerDownRight, Gauge, Save, Send, X } from 'lucide-react'
 import { useAppStore, type RailItem } from '@/stores/app'
 import { useTabsStore } from '@/stores/tabs'
 import { useCollectionsStore } from '@/stores/collections'
@@ -15,7 +15,7 @@ import { HostBar } from '@/components/hosts/HostBar'
 import { WelcomePanel } from '@/components/layout/WelcomePanel'
 import { LoadTestDrawer } from '@/components/loadtest/LoadTestDrawer'
 import { executeRequest } from '@/lib/executeRequest'
-import { uid, type EnvVariable, type HttpMethod, type RequestItem } from '@/lib/types'
+import { uid, type Collection, type EnvVariable, type HttpMethod, type RequestItem, type TreeNode } from '@/lib/types'
 import { useT } from '@/lib/i18n'
 import { safeSetItem } from '@/lib/safeLocalStorage'
 import { VarHighlightInput } from '@/components/ui/VarHighlightInput'
@@ -140,6 +140,7 @@ function loadComposerWidth(): number {
 
 function ActiveRequestBar({
   request,
+  breadcrumb,
   isDirty,
   loading,
   vars,
@@ -150,6 +151,7 @@ function ActiveRequestBar({
   onLoadTest,
 }: {
   request: RequestItem
+  breadcrumb: string[]
   isDirty: boolean
   loading?: boolean
   vars: Record<string, string>
@@ -176,6 +178,14 @@ function ActiveRequestBar({
 
   return (
     <div className="border-b border-border-1 bg-surface-1/95 px-3 py-2">
+      <div className="mb-1.5 flex min-w-0 items-center gap-1 font-mono text-[10px] text-text-4">
+        {(breadcrumb.length ? breadcrumb : ['Unsaved request']).map((part, index) => (
+          <span key={`${part}-${index}`} className="flex min-w-0 items-center gap-1">
+            {index > 0 && <ChevronRight size={10} className="shrink-0 text-text-4" />}
+            <span className={cn('truncate', index === breadcrumb.length - 1 ? 'text-text-2' : 'text-text-4')}>{part}</span>
+          </span>
+        ))}
+      </div>
       <div className="flex min-w-0 items-center gap-2">
         <div className="flex min-w-[150px] max-w-[240px] flex-col gap-0.5">
           <span className="text-[9px] font-semibold uppercase tracking-[0.14em] text-accent">Active Request</span>
@@ -279,6 +289,21 @@ function ActiveRequestBar({
   )
 }
 
+function findRequestPath(collection: Collection, requestId: string): string[] | null {
+  const walk = (nodes: TreeNode[], trail: string[]): string[] | null => {
+    for (const node of nodes) {
+      if (node.type === 'request' && node.id === requestId) return [...trail, node.name || 'Untitled']
+      if (node.type === 'folder') {
+        const found = walk(node.children, [...trail, node.name])
+        if (found) return found
+      }
+    }
+    return null
+  }
+  const found = walk(collection.children, [collection.name])
+  return found
+}
+
 // ─── RequestWorkspace ─────────────────────────────────────────────────────────
 
 function RequestWorkspace() {
@@ -367,6 +392,12 @@ function RequestWorkspace() {
   // ── End resizable split ─────────────────────────────────────────────────────
 
   const activeTab = tabs.find((t) => t.id === activeTabId)
+  const activeBreadcrumb = activeTab?.collectionId
+    ? (() => {
+        const collection = collections.find((item) => item.id === activeTab.collectionId)
+        return collection ? findRequestPath(collection, activeTab.request.id) ?? [collection.name, activeTab.request.name || 'Untitled'] : []
+      })()
+    : []
 
   const oaSpec =
     activeTab?.collectionId
@@ -519,6 +550,7 @@ function RequestWorkspace() {
       {activeTab && (
         <ActiveRequestBar
           request={activeTab.request}
+          breadcrumb={activeBreadcrumb}
           isDirty={activeTab.dirty}
           loading={activeTab.loading}
           vars={getResolvedVars()}

--- a/frontend/src/components/layout/WelcomePanel.tsx
+++ b/frontend/src/components/layout/WelcomePanel.tsx
@@ -23,6 +23,7 @@ import {
   Send,
   Server,
   Shield,
+  UploadCloud,
   Zap,
 } from 'lucide-react'
 import { useAppStore, type RailItem } from '@/stores/app'
@@ -147,6 +148,7 @@ export function WelcomePanel() {
   const environments = useEnvironmentsStore((s) => s.environments)
   const activeEnvId = useEnvironmentsStore((s) => s.activeEnvId)
   const tabs = useTabsStore((s) => s.tabs)
+  const newTab = useTabsStore((s) => s.newTab)
   const responseHistory = useTabsStore((s) => s.responseHistory)
   const [openLayers, setOpenLayers] = useState<Set<LayerId>>(() => new Set())
   const [recentWorkspaces, setRecentWorkspaces] = useState<RecentWorkspace[]>(loadRecentWorkspaces)
@@ -162,6 +164,7 @@ export function WelcomePanel() {
     () => collections.reduce((total, collection) => total + countRequests(collection.children), 0),
     [collections],
   )
+  const isEmptyWorkspace = collections.length === 0 && environments.length === 0 && tabs.length === 0
   const activeEnvironment = environments.find((environment) => environment.id === activeEnvId)
   const runningServices = [
     mockRunning && 'Mock',
@@ -249,13 +252,17 @@ export function WelcomePanel() {
             <div className="min-w-0">
               <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-accent/20 bg-accent/10 px-3 py-1 font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-accent">
                 <Layers size={12} />
-                Local developer toolbox
+                Local-first developer toolbox
               </div>
               <h1 className="m-0 font-sans text-[34px] font-semibold leading-none tracking-[-0.02em] text-text-1">
-                Build, test and debug APIs from one private desktop workspace.
+                {isEmptyWorkspace
+                  ? 'Drop your API files and start from your real workspace.'
+                  : 'Build, test and debug APIs from one private desktop workspace.'}
               </h1>
               <p className="mt-3 max-w-2xl font-mono text-[12px] leading-relaxed text-text-3">
-                adOmnia brings API clients, mocks, brokers, proxy inspection, browser debugging and local data tools into a single offline-first environment. Your collections, secrets, traffic captures and workspaces stay on your machine.
+                {isEmptyWorkspace
+                  ? 'Start clean: drag Postman, Insomnia, Bruno, OpenAPI, .adomnia, .har or .wsdl files anywhere in this window. adOmnia imports them locally, with no account and no cloud sync.'
+                  : 'adOmnia brings API clients, mocks, brokers, proxy inspection, browser debugging and local data tools into a single offline-first environment. Your collections, secrets, traffic captures and workspaces stay on your machine.'}
               </p>
               <div className="mt-5 hidden items-center gap-3 xl:flex">
                 <MetricPill label="collections" value={String(collections.length)} />
@@ -303,6 +310,44 @@ export function WelcomePanel() {
               />
             </div>
           </header>
+
+          {isEmptyWorkspace && (
+            <section className="mb-5 grid gap-4 overflow-hidden rounded-2xl border border-accent/25 bg-accent/[0.06] p-5 shadow-lg shadow-black/5 lg:grid-cols-[minmax(0,1fr)_auto]">
+              <div className="flex min-w-0 gap-4">
+                <div className="grid h-12 w-12 shrink-0 place-items-center rounded-xl border border-accent/30 bg-accent/10 text-accent">
+                  <UploadCloud size={22} />
+                </div>
+                <div className="min-w-0">
+                  <h2 className="text-sm font-semibold text-text-1">Start with an import</h2>
+                  <p className="mt-1 max-w-3xl font-mono text-[11px] leading-relaxed text-text-3">
+                    Drop files directly on the app to populate the API workspace, open HAR captures, or route WSDL files into SOAP Studio. You can also create a blank request if you want to test a single URL first.
+                  </p>
+                  <div className="mt-3 flex flex-wrap gap-2 font-mono text-[10px] text-text-3">
+                    {['Postman', 'OpenAPI', 'Insomnia', 'Bruno', '.adomnia', '.har', '.wsdl'].map((format) => (
+                      <span key={format} className="rounded border border-border-2 bg-surface-1 px-2 py-1">{format}</span>
+                    ))}
+                  </div>
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={() => {
+                    newTab()
+                    setActiveRail('collections')
+                  }}
+                  className="rounded-lg border border-border-2 bg-surface-1 px-3 py-2 text-xs font-medium text-text-2 transition-colors hover:border-accent/40 hover:text-text-1"
+                >
+                  Blank request
+                </button>
+                <button
+                  onClick={() => setActiveRail('workspace')}
+                  className="rounded-lg bg-accent px-3 py-2 text-xs font-semibold text-white transition-colors hover:bg-accent-hover"
+                >
+                  Workspace import
+                </button>
+              </div>
+            </section>
+          )}
 
           <section className="mb-5 overflow-hidden rounded-2xl border border-border-1 bg-surface-1 shadow-lg shadow-black/5">
             <div className="flex items-center justify-between gap-4 border-b border-border-1 px-5 py-3.5">

--- a/frontend/src/hooks/useAppInit.ts
+++ b/frontend/src/hooks/useAppInit.ts
@@ -7,7 +7,6 @@ import { useTabsStore } from '@/stores/tabs'
 import { useAppStore } from '@/stores/app'
 import { useDevLogsStore } from '@/stores/devLogs'
 import { getBackendDevLogs, clearBackendDevLogs } from '@/lib/devlogs-api'
-import { loadDefaultPostmanDemo } from '@/lib/demoWorkspace'
 import { GetStartupWindowChrome } from '@/wailsjs/go/main/App'
 
 type WindowChromeMode = 'app' | 'app-xwayland' | 'system'
@@ -111,10 +110,6 @@ export function useAppInit(): AppInitResult {
     if (collectionsLoadError || environmentsLoadError) return
     const collectionsEmpty = useCollectionsStore.getState().collections.length === 0
     const environmentsEmpty = useEnvironmentsStore.getState().environments.length === 0
-    if (collectionsEmpty && environmentsEmpty && loadDefaultPostmanDemo()) {
-      setActiveRail('collections')
-      return
-    }
     if (collectionsEmpty && environmentsEmpty && showWelcomeOnEmpty) {
       setActiveRail('welcome')
     }

--- a/frontend/src/stores/tabs.ts
+++ b/frontend/src/stores/tabs.ts
@@ -15,7 +15,7 @@ type PersistedTabsState = {
   responseHistory: Array<RequestHistoryEntry | ResponseData>
 }
 
-export type ComposerSection = 'params' | 'headers' | 'cookies' | 'body' | 'auth' | 'scripts' | 'tests' | 'notes'
+export type ComposerSection = 'overview' | 'params' | 'headers' | 'cookies' | 'body' | 'auth' | 'scripts' | 'tests' | 'notes'
 export type ResponseSection = 'body' | 'headers' | 'contract' | 'assertions'
 export type ResponseBodyView = 'pretty' | 'raw' | 'graph'
 export type TabDropPosition = 'before' | 'after'
@@ -87,7 +87,7 @@ function normalizeHistoryEntries(history: Array<RequestHistoryEntry | ResponseDa
 
 function defaultViewState(): TabViewState {
   return {
-    composerSection: 'body',
+    composerSection: 'overview',
     composerScrollTop: 0,
     composerContentScrollTop: {},
     responseSection: 'body',

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -21,6 +21,7 @@ export namespace apis {
 	    categories: string[];
 	    type: string;
 	    isFree: boolean;
+	    source?: string;
 	    links: [];
 	
 	    static createFrom(source: any = {}) {
@@ -35,6 +36,7 @@ export namespace apis {
 	        this.categories = source["categories"];
 	        this.type = source["type"];
 	        this.isFree = source["isFree"];
+	        this.source = source["source"];
 	        this.links = this.convertValues(source["links"], );
 	    }
 	


### PR DESCRIPTION
… users toward drag-and-drop imports, and add a Postman-style request overview with breadcrumb, documentation, setup checklist, variables, and calmer collection sidebar hierarchy.

---
name: Pull Request
about: Submit code changes
title: ''
labels: ''
assignees: ''
---

## Summary

Describe what changed and why.

## Product Impact

What user workflow improves? Include screenshots or recordings for UI changes.

## Type

- [ ] Bug fix
- [x] Feature
- [x] UI/UX polish
- [ ] Documentation
- [ ] Build/release
- [x] Refactor
- [ ] Security/privacy

## Verification

- [x] `cd frontend && npm run build`
- [x] `go test ./...`
- [ ] Manual smoke test performed
- [ ] Not applicable

Manual test notes:

## Risk

- [ ] Low: isolated change
- [ ] Medium: shared UI/state/build behavior
- [ ] High: storage, workspace format, security, release pipeline, or network behavior

## Checklist

- [ ] The change preserves local-first behavior.
- [ ] User-facing behavior is documented.
- [ ] Screenshots are included for visible UI changes.
- [ ] `CHANGELOG.md` is updated under `[Unreleased]` if release-worthy.
- [ ] Secrets, tokens, cookies, and private URLs are not included in logs/screenshots.

## Related Issues

Fixes #
