### PR TITLE
feat: add multi-collection workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ check rest apis:
 
 | Area | What you get |
 |---|---|
-| **API Workspace** | HTTP client (all methods), collections, environments, `{{variable}}` substitution, OAuth2 PKCE, AWS Signature v4, Digest, cURL import, OpenAPI import, pre/post scripts, assertions, code generation (13 languages), response history |
+| **API Workspace** | Multiple local workspaces with independent collections and tabs, HTTP client (all methods), environments, `{{variable}}` substitution, OAuth2 PKCE, AWS Signature v4, Digest, cURL/OpenAPI import, scripts, assertions, code generation, response history |
 | **API Catalog** | Installable public REST API starters, including curated no-auth/free endpoints inspired by `public-apis/public-apis`, imported directly into local adOmnia collections |
 | **Collection Runner & Testing** | Test runner with iterations/delay/retry/CSV datasets, assertion editor (JSONPath, XPath, schema), Mermaid-generated API flows, test data studio (fake data generator) |
 | **Protocols** | SOAP/WSDL Studio (1.1 & 1.2, WS-Security), gRPC (server reflection, unary + streaming), WebSocket client + mock server, SSE client, **MCP Client** (AI tool testing, stdio + HTTP transport) |
@@ -111,7 +111,7 @@ adOmnia es un **toolbox profesional de desarrollo de APIs** para desarrolladores
 
 | Área | Qué incluye |
 |---|---|
-| **API Workspace** | Cliente HTTP completo, colecciones, entornos, sustitución `{{variable}}`, OAuth2 PKCE, AWS v4, import cURL/OpenAPI, scripts pre/post, assertions, generación de código (13 lenguajes) |
+| **API Workspace** | Workspaces locales múltiples con colecciones y pestañas independientes, cliente HTTP completo, entornos, sustitución `{{variable}}`, OAuth2 PKCE, AWS v4, import cURL/OpenAPI, scripts, assertions, generación de código |
 | **Testing y Runner** | Runner con iteraciones/delay/CSV, assertion editor (JSONPath, XPath, schema), flows API desde Mermaid, test data studio |
 | **Protocolos** | SOAP/WSDL Studio (WS-Security), gRPC (reflection + streaming), WebSocket + mock server, SSE, **MCP Client** (prueba servidores MCP de IA) |
 | **Mensajería** | Kafka, RabbitMQ, MQTT, Redis Pub/Sub, NATS — log compartido, perfiles persistentes |
@@ -163,7 +163,7 @@ adOmnia è un **toolbox professionale per lo sviluppo di API** pensato per chi v
 
 | Area | Cosa include |
 |---|---|
-| **API Workspace** | Client HTTP completo, collezioni, ambienti, sostituzione `{{variabile}}`, OAuth2 PKCE, AWS Signature v4, import cURL/OpenAPI, script pre/post, assertion, generazione codice (13 linguaggi) |
+| **API Workspace** | Workspace locali multipli con collection e tab indipendenti, client HTTP completo, ambienti, sostituzione `{{variabile}}`, OAuth2 PKCE, AWS Signature v4, import cURL/OpenAPI, script, assertion, generazione codice |
 | **Testing e Runner** | Runner con iterazioni/delay/CSV, assertion editor (JSONPath, XPath, schema), flow API generati da Mermaid, test data studio |
 | **Protocolli** | SOAP/WSDL Studio (WS-Security), gRPC (server reflection + streaming), WebSocket + mock server, SSE, **MCP Client** (test server MCP per IA) |
 | **Broker** | Kafka, RabbitMQ, MQTT, Redis Pub/Sub, NATS — log messaggi condiviso, profili connessione persistenti |

--- a/docs/funzionalita.md
+++ b/docs/funzionalita.md
@@ -588,13 +588,14 @@ Tutte le funzionalità sono offline-first: nessun account, nessuna telemetria, n
 
 | # | Funzionalità | Descrizione |
 |---|-------------|-------------|
-| E3.1 | **Workspace Nominati** | Salva e commuta tra workspace multipli; ognuno include collezioni, ambienti, tab, impostazioni. |
-| E3.2 | **Salva Workspace** | Snapshot corrente con nome, timestamp, conteggio tab. |
+| E3.1 | **Workspace Nominati Multi-Collection** | Crea, rinomina, elimina e commuta tra workspace locali; ogni workspace contiene un insieme indipendente di collection. I dati esistenti vengono migrati automaticamente nel workspace predefinito. |
+| E3.2 | **Tab Separate per Workspace** | Le tab aperte seguono il workspace di appartenenza e vengono ripristinate quando si torna a quel workspace. |
 | E3.3 | **Carica Workspace** | Ripristina stato da workspace nominato e aggiorna la cronologia locale dei workspace aperti di recente. |
-| E3.4 | **Elimina Workspace** | Rimuove workspace dal registro. |
+| E3.4 | **Sposta Collection tra Workspace** | Dal menu contestuale di una collection la sposta in un altro workspace mantenendo le relative tab aperte. |
 | E3.5 | **Import/Export `.adomnia`** | Formato JSON portabile (v1.0): collezioni, ambienti, activeEnvId, mockConfig, proxyConfig, flows. |
 | E3.6 | **Import OpenAPI 3.0** | Parsing spec JSON/YAML; operazioni convertite in cartelle raggruppate per tag. |
 | E3.7 | **Reset Demo** | Carica workspace demo adOmnia Lab con un click. |
+| E3.8 | **Snapshot Workspace Attivo** | Salva e carica backup nominati dello stato del workspace attivo, inclusi collection e tab del relativo contesto. |
 
 ---
 

--- a/frontend/src/components/collections/CollectionTree.tsx
+++ b/frontend/src/components/collections/CollectionTree.tsx
@@ -8,6 +8,7 @@ import {
   FolderPlus,
   GripVertical,
   Link,
+  Layers,
   Plus,
   Search,
   Trash2,
@@ -45,6 +46,8 @@ interface CollectionTreeProps {
   onDuplicateNode: (collectionId: string, nodeId: string) => TreeNode | null
   onAddRequestToFolder: (collectionId: string, parentId: string | null, method?: HttpMethod) => void
   onImportCollection: (collection: Collection) => void
+  workspaceTargets: Array<{ id: string; name: string }>
+  onMoveCollectionToWorkspace: (collectionId: string, workspaceId: string) => void
   onReorderCollections: (fromId: string, toId: string) => void
   onMoveNode: (collectionId: string, nodeId: string, targetCollectionId: string, targetParentId: string | null, targetIndex: number) => void
 }
@@ -413,6 +416,8 @@ export function CollectionTree({
   onDuplicateNode,
   onAddRequestToFolder,
   onImportCollection,
+  workspaceTargets,
+  onMoveCollectionToWorkspace,
   onReorderCollections,
   onMoveNode,
 }: CollectionTreeProps) {
@@ -649,7 +654,7 @@ export function CollectionTree({
   )
 
   return (
-    <div className="relative flex h-full flex-col">
+    <div className="relative flex min-h-0 flex-1 flex-col">
       <div className="flex items-center gap-1 border-b border-border-1 px-2 py-2">
         <span className="flex-1 text-[10px] font-semibold uppercase tracking-wider text-text-4">Collections</span>
         <input ref={fileInputRef} type="file" accept=".json,.yaml,.yml,.bru" className="hidden" onChange={(event) => void handleImport(event.target.files?.[0])} />
@@ -770,13 +775,29 @@ export function CollectionTree({
       </div>
 
       {context && (
-        <div ref={menuRef} className="fixed z-50 w-52 rounded-md border border-border-1 bg-surface-1 py-1 shadow-xl" style={{ left: context.x, top: context.y }}>
+        <div ref={menuRef} className="fixed z-50 max-h-[70vh] w-52 overflow-y-auto rounded-md border border-border-1 bg-surface-1 py-1 shadow-xl" style={{ left: context.x, top: context.y }}>
           {context.kind === 'collection' && (
             <>
               <MenuButton onClick={() => { setEditingId(context.collection.id); setContext(null) }}><Copy size={12} /> Rename</MenuButton>
               <MenuButton onClick={() => { onImportCollection(cloneCollection(context.collection)); setContext(null) }}><Copy size={12} /> Duplicate</MenuButton>
               <MenuButton onClick={() => { setFolderPrompt({ collectionId: context.collection.id, parentId: null }); setContext(null) }}><FolderPlus size={12} /> New Folder</MenuButton>
               <MenuButton onClick={() => { onAddRequestToFolder(context.collection.id, null); setContext(null) }}><Plus size={12} /> New Request</MenuButton>
+              {workspaceTargets.length > 0 && (
+                <div className="border-t border-border-1 py-1">
+                  <div className="px-3 py-1 text-[9px] font-semibold uppercase tracking-wider text-text-4">Move to workspace</div>
+                  {workspaceTargets.map((workspace) => (
+                    <MenuButton
+                      key={workspace.id}
+                      onClick={() => {
+                        onMoveCollectionToWorkspace(context.collection.id, workspace.id)
+                        setContext(null)
+                      }}
+                    >
+                      <Layers size={12} /> {workspace.name}
+                    </MenuButton>
+                  ))}
+                </div>
+              )}
               {contextExportMenu(context)}
               <MenuButton danger onClick={() => { setDeleteTarget(context); setContext(null) }}><Trash2 size={12} /> Delete</MenuButton>
             </>

--- a/frontend/src/components/layout/CommandPalette.tsx
+++ b/frontend/src/components/layout/CommandPalette.tsx
@@ -41,6 +41,7 @@ export function CommandPalette({ open, onClose }: CommandPaletteProps) {
   const [selectedIndex, setSelectedIndex] = useState(0)
   const inputRef = useRef<HTMLInputElement>(null)
   const collections = useCollectionsStore((s) => s.collections)
+  const activeWorkspaceId = useCollectionsStore((s) => s.activeWorkspaceId)
   const environments = useEnvironmentsStore((s) => s.environments)
   const activeEnvId = useEnvironmentsStore((s) => s.activeEnvId)
   const setActiveEnv = useEnvironmentsStore((s) => s.setActiveEnv)
@@ -98,7 +99,7 @@ export function CommandPalette({ open, onClose }: CommandPaletteProps) {
       group: 'Panels', keywords: `${panel.keywords} ${panel.group}`, icon: ArrowRight,
       run: () => setActiveRail(panel.id),
     }))
-    const recentRequests = tabs.slice().reverse().map<PaletteCommand>((tab) => ({
+    const recentRequests = tabs.filter((tab) => (tab.workspaceId ?? activeWorkspaceId) === activeWorkspaceId).reverse().map<PaletteCommand>((tab) => ({
       id: `recent:${tab.id}`, title: tab.request.name || tab.request.url || 'Untitled Request',
       subtitle: `${tab.request.method} ${tab.request.url || 'No URL'}`, group: 'Recent Requests',
       keywords: `${tab.request.method} ${tab.request.url} ${tab.request.name}`, icon: ArrowRight,
@@ -125,7 +126,7 @@ export function CommandPalette({ open, onClose }: CommandPaletteProps) {
       run: () => setActiveEnv(environment.id),
     }))
     return [...actions, ...panels, ...recentRequests, ...collectionEntries, ...environmentEntries]
-  }, [activeEnvId, collections, environments, newTab, openTab, setActiveEnv, setActiveRail, tabs])
+  }, [activeEnvId, activeWorkspaceId, collections, environments, newTab, openTab, setActiveEnv, setActiveRail, tabs])
 
   const results = useMemo(() => commands
     .map((command) => ({ command, score: fuzzyScore(query, `${command.title} ${command.subtitle ?? ''} ${command.keywords}`) }))

--- a/frontend/src/components/layout/MainArea.tsx
+++ b/frontend/src/components/layout/MainArea.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef, Suspense } from 'react'
+import React, { useState, useEffect, useCallback, useMemo, useRef, Suspense } from 'react'
 import { ArrowLeft, Check, ChevronRight, Clock, CornerDownRight, Gauge, Save, Send, X } from 'lucide-react'
 import { useAppStore, type RailItem } from '@/stores/app'
 import { useTabsStore } from '@/stores/tabs'
@@ -307,7 +307,7 @@ function findRequestPath(collection: Collection, requestId: string): string[] | 
 // ─── RequestWorkspace ─────────────────────────────────────────────────────────
 
 function RequestWorkspace() {
-  const tabs = useTabsStore((s) => s.tabs)
+  const allTabs = useTabsStore((s) => s.tabs)
   const activeTabId = useTabsStore((s) => s.activeTabId)
   const setActiveTab = useTabsStore((s) => s.setActiveTab)
   const closeTab = useTabsStore((s) => s.closeTab)
@@ -323,6 +323,11 @@ function RequestWorkspace() {
   const updateViewState = useTabsStore((s) => s.updateViewState)
   const updateCollectionRequest = useCollectionsStore((s) => s.updateRequest)
   const collections = useCollectionsStore((s) => s.collections)
+  const activeWorkspaceId = useCollectionsStore((s) => s.activeWorkspaceId)
+  const tabs = useMemo(
+    () => allTabs.filter((tab) => (tab.workspaceId ?? activeWorkspaceId) === activeWorkspaceId),
+    [activeWorkspaceId, allTabs],
+  )
   const confirmBeforeClosingDirtyTabs = useSettingsStore((s) => s.settings.general.confirmBeforeClosingDirtyTabs)
 
   const environments = useEnvironmentsStore((s) => s.environments)

--- a/frontend/src/components/layout/OnboardingPanel.tsx
+++ b/frontend/src/components/layout/OnboardingPanel.tsx
@@ -205,7 +205,6 @@ function ToolCard({ tool, onClick, topAccent = false }: {
 export function OnboardingPanel() {
   const setActiveRail = useAppStore((s) => s.setActiveRail)
   const newTab = useTabsStore((s) => s.newTab)
-  const saveCollections = useCollectionsStore((s) => s.save)
   const saveEnvironments = useEnvironmentsStore((s) => s.save)
   const port = useServerPort()
 
@@ -217,9 +216,9 @@ export function OnboardingPanel() {
 
   const loadDemo = async () => {
     const demo = createAdomniaLabWorkspace(serverUrl(port, ''))
-    useCollectionsStore.setState({ collections: migrateCollections(demo.collections), loaded: true })
+    useCollectionsStore.getState().replaceCollections(migrateCollections(demo.collections))
     useEnvironmentsStore.setState({ environments: demo.environments, activeEnvId: demo.activeEnvId, loaded: true })
-    await Promise.all([saveCollections(), saveEnvironments()])
+    await saveEnvironments()
     safeSetItem(ONBOARDED_KEY, '1')
     setActiveRail('collections')
   }

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { ChevronDown, FolderKanban, Pencil, Plus, Trash2 } from 'lucide-react'
 import { useAppStore } from '@/stores/app'
 import { useSettingsStore } from '@/stores/settings'
 import { useCollectionsStore } from '@/stores/collections'
@@ -7,11 +8,20 @@ import { CollectionTree } from '@/components/collections/CollectionTree'
 import { blankRequest, uid } from '@/lib/types'
 import type { HttpMethod, RequestItem } from '@/lib/types'
 import { Prompt } from '@/components/ui/prompt'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import { cn } from '@/lib/utils'
 
 export function Sidebar() {
   const activeRail = useAppStore((s) => s.activeRail)
   const collapsed = useSettingsStore((s) => s.settings.appearance.sidebarCollapsed)
   const collections = useCollectionsStore((s) => s.collections)
+  const workspaces = useCollectionsStore((s) => s.workspaces)
+  const activeWorkspaceId = useCollectionsStore((s) => s.activeWorkspaceId)
+  const addWorkspace = useCollectionsStore((s) => s.addWorkspace)
+  const renameWorkspace = useCollectionsStore((s) => s.renameWorkspace)
+  const deleteWorkspace = useCollectionsStore((s) => s.deleteWorkspace)
+  const setActiveWorkspace = useCollectionsStore((s) => s.setActiveWorkspace)
+  const moveCollectionToWorkspace = useCollectionsStore((s) => s.moveCollectionToWorkspace)
   const addCollection = useCollectionsStore((s) => s.addCollection)
   const deleteCollection = useCollectionsStore((s) => s.deleteCollection)
   const deleteNode = useCollectionsStore((s) => s.deleteNode)
@@ -27,11 +37,20 @@ export function Sidebar() {
   const newTab = useTabsStore((s) => s.newTab)
   const activeTabId = useTabsStore((s) => s.activeTabId)
   const tabs = useTabsStore((s) => s.tabs)
+  const activateWorkspace = useTabsStore((s) => s.activateWorkspace)
+  const deleteWorkspaceTabs = useTabsStore((s) => s.deleteWorkspaceTabs)
+  const moveCollectionTabs = useTabsStore((s) => s.moveCollectionTabs)
   const [showAddCollection, setShowAddCollection] = useState(false)
+  const [showAddWorkspace, setShowAddWorkspace] = useState(false)
+  const [showRenameWorkspace, setShowRenameWorkspace] = useState(false)
+  const [showDeleteWorkspace, setShowDeleteWorkspace] = useState(false)
 
   if (collapsed || activeRail !== 'collections') return null
 
-  const activeRequestId = tabs.find((t) => t.id === activeTabId)?.request.id ?? null
+  const activeWorkspace = workspaces.find((workspace) => workspace.id === activeWorkspaceId)
+  const workspaceTabs = tabs.filter((tab) => (tab.workspaceId ?? activeWorkspaceId) === activeWorkspaceId)
+  const dirtyWorkspaceTabs = workspaceTabs.filter((tab) => tab.dirty).length
+  const activeRequestId = tabs.find((t) => t.id === activeTabId && (t.workspaceId ?? activeWorkspaceId) === activeWorkspaceId)?.request.id ?? null
 
   const handleDuplicateRequest = (collectionId: string, request: RequestItem) => {
     const dupe: RequestItem = { ...request, id: uid(), name: `${request.name} (copy)` }
@@ -44,8 +63,55 @@ export function Sidebar() {
     openTab(req, collectionId)
   }
 
+  const handleSwitchWorkspace = (workspaceId: string) => {
+    setActiveWorkspace(workspaceId)
+    activateWorkspace(workspaceId)
+  }
+
+  const handleMoveCollection = (collectionId: string, workspaceId: string) => {
+    moveCollectionToWorkspace(collectionId, workspaceId)
+    moveCollectionTabs(collectionId, workspaceId)
+  }
+
   return (
-    <aside className="w-full flex-shrink-0 bg-surface-0 border-r border-border-1 flex flex-col">
+    <aside className="h-full min-h-0 w-full flex-shrink-0 bg-surface-0 border-r border-border-1 flex flex-col">
+      <div className="border-b border-border-1 bg-surface-1/55 px-2 py-2">
+        <div className="mb-1.5 flex items-center gap-2 px-1">
+          <FolderKanban size={12} className="text-accent" />
+          <span className="min-w-0 flex-1 truncate text-[9px] font-semibold uppercase tracking-[0.14em] text-text-4">Workspace</span>
+          <span className="text-[9px] text-text-4">{collections.length} collections</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <div className="relative min-w-0 flex-1">
+            <select
+              value={activeWorkspaceId}
+              onChange={(event) => handleSwitchWorkspace(event.target.value)}
+              className="h-8 w-full appearance-none truncate rounded-md border border-border-2 bg-surface-2 pl-2.5 pr-7 text-xs font-medium text-text-1 outline-none transition-colors hover:border-accent/40 focus:border-accent"
+              title="Active workspace"
+            >
+              {workspaces.map((workspace) => (
+                <option key={workspace.id} value={workspace.id}>{workspace.name}</option>
+              ))}
+            </select>
+            <ChevronDown size={12} className="pointer-events-none absolute right-2 top-2 text-text-4" />
+          </div>
+          <button onClick={() => setShowAddWorkspace(true)} title="New workspace" className="grid h-8 w-7 place-items-center rounded-md text-text-3 hover:bg-surface-2 hover:text-text-1">
+            <Plus size={13} />
+          </button>
+          <button onClick={() => setShowRenameWorkspace(true)} title="Rename workspace" className="grid h-8 w-7 place-items-center rounded-md text-text-3 hover:bg-surface-2 hover:text-text-1">
+            <Pencil size={12} />
+          </button>
+          <button
+            onClick={() => setShowDeleteWorkspace(true)}
+            disabled={workspaces.length <= 1}
+            title={workspaces.length <= 1 ? 'At least one workspace is required' : 'Delete workspace'}
+            className={cn('grid h-8 w-7 place-items-center rounded-md text-text-3 hover:bg-error/10 hover:text-error', workspaces.length <= 1 && 'cursor-not-allowed opacity-35')}
+          >
+            <Trash2 size={12} />
+          </button>
+        </div>
+      </div>
+
       <CollectionTree
         collections={collections}
         activeRequestId={activeRequestId}
@@ -61,6 +127,8 @@ export function Sidebar() {
         onDuplicateNode={duplicateNode}
         onAddRequestToFolder={handleAddRequestToFolder}
         onImportCollection={importCollection}
+        workspaceTargets={workspaces.filter((workspace) => workspace.id !== activeWorkspaceId)}
+        onMoveCollectionToWorkspace={handleMoveCollection}
         onReorderCollections={reorderCollections}
         onMoveNode={moveNode}
       />
@@ -75,6 +143,48 @@ export function Sidebar() {
           setShowAddCollection(false)
         }}
         onCancel={() => setShowAddCollection(false)}
+      />
+
+      <Prompt
+        open={showAddWorkspace}
+        title="New Workspace"
+        placeholder="Workspace name..."
+        confirmLabel="Create"
+        onConfirm={(name) => {
+          const workspace = addWorkspace(name)
+          handleSwitchWorkspace(workspace.id)
+          setShowAddWorkspace(false)
+        }}
+        onCancel={() => setShowAddWorkspace(false)}
+      />
+
+      <Prompt
+        open={showRenameWorkspace}
+        title="Rename Workspace"
+        defaultValue={activeWorkspace?.name ?? ''}
+        placeholder="Workspace name..."
+        confirmLabel="Rename"
+        onConfirm={(name) => {
+          renameWorkspace(activeWorkspaceId, name)
+          setShowRenameWorkspace(false)
+        }}
+        onCancel={() => setShowRenameWorkspace(false)}
+      />
+
+      <ConfirmDialog
+        open={showDeleteWorkspace}
+        title="Delete workspace?"
+        message={`Delete "${activeWorkspace?.name ?? 'this workspace'}", its ${collections.length} collection${collections.length === 1 ? '' : 's'} and ${workspaceTabs.length} open tab${workspaceTabs.length === 1 ? '' : 's'}${dirtyWorkspaceTabs ? ` (${dirtyWorkspaceTabs} with unsaved changes)` : ''}? This cannot be undone.`}
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={() => {
+          const deletedId = activeWorkspaceId
+          const nextWorkspaceId = deleteWorkspace(deletedId)
+          deleteWorkspaceTabs(deletedId)
+          if (nextWorkspaceId) activateWorkspace(nextWorkspaceId)
+          setShowDeleteWorkspace(false)
+        }}
+        onCancel={() => setShowDeleteWorkspace(false)}
       />
     </aside>
   )

--- a/frontend/src/components/layout/StatusBar.tsx
+++ b/frontend/src/components/layout/StatusBar.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
-import { Moon, Sun } from 'lucide-react'
+import { FolderKanban, Moon, Sun } from 'lucide-react'
 import { useEnvironmentsStore } from '@/stores/environments'
+import { useCollectionsStore } from '@/stores/collections'
 import { useTabsStore } from '@/stores/tabs'
 import { useAppStore } from '@/stores/app'
 import { useThemesStore } from '@/stores/themes'
@@ -14,6 +15,8 @@ export function StatusBar() {
   const tabs = useTabsStore((s) => s.tabs)
   const activeTabId = useTabsStore((s) => s.activeTabId)
   const responseHistory = useTabsStore((s) => s.responseHistory)
+  const workspaces = useCollectionsStore((s) => s.workspaces)
+  const activeWorkspaceId = useCollectionsStore((s) => s.activeWorkspaceId)
   const mockRunning = useAppStore((s) => s.mockRunning)
   const proxyRunning = useAppStore((s) => s.proxyRunning)
   const setActiveRail = useAppStore((s) => s.setActiveRail)
@@ -33,6 +36,7 @@ export function StatusBar() {
   }, [])
 
   const activeEnv = environments.find((e) => e.id === activeEnvId)
+  const activeWorkspace = workspaces.find((workspace) => workspace.id === activeWorkspaceId)
   const activeTab = tabs.find((t) => t.id === activeTabId)
   const response = activeTab?.response
   const activeTheme = themes.find((t) => t.id === activeThemeId)
@@ -89,6 +93,19 @@ export function StatusBar() {
         )}
       </div>
       <div className="flex items-center gap-2">
+        {activeWorkspace && (
+          <>
+            <button
+              onClick={() => setActiveRail('collections')}
+              title="Open active workspace"
+              className="flex max-w-44 items-center gap-1 text-text-4 transition-colors hover:text-text-2"
+            >
+              <FolderKanban size={10} className="shrink-0 text-accent" />
+              <span className="truncate">{activeWorkspace.name}</span>
+            </button>
+            <span className="h-3 w-px bg-border-2" />
+          </>
+        )}
         {/* Mock running indicator — click to navigate */}
         {mockRunning && (
           <button

--- a/frontend/src/components/layout/WelcomePanel.tsx
+++ b/frontend/src/components/layout/WelcomePanel.tsx
@@ -145,9 +145,10 @@ export function WelcomePanel() {
   const sseRunning = useAppStore((s) => s.sseRunning)
   const browserRunning = useAppStore((s) => s.browserRunning)
   const collections = useCollectionsStore((s) => s.collections)
+  const activeWorkspaceId = useCollectionsStore((s) => s.activeWorkspaceId)
   const environments = useEnvironmentsStore((s) => s.environments)
   const activeEnvId = useEnvironmentsStore((s) => s.activeEnvId)
-  const tabs = useTabsStore((s) => s.tabs)
+  const allTabs = useTabsStore((s) => s.tabs)
   const newTab = useTabsStore((s) => s.newTab)
   const responseHistory = useTabsStore((s) => s.responseHistory)
   const [openLayers, setOpenLayers] = useState<Set<LayerId>>(() => new Set())
@@ -163,6 +164,10 @@ export function WelcomePanel() {
   const requestCount = useMemo(
     () => collections.reduce((total, collection) => total + countRequests(collection.children), 0),
     [collections],
+  )
+  const tabs = useMemo(
+    () => allTabs.filter((tab) => (tab.workspaceId ?? activeWorkspaceId) === activeWorkspaceId),
+    [activeWorkspaceId, allTabs],
   )
   const isEmptyWorkspace = collections.length === 0 && environments.length === 0 && tabs.length === 0
   const activeEnvironment = environments.find((environment) => environment.id === activeEnvId)

--- a/frontend/src/components/response/DiffView.tsx
+++ b/frontend/src/components/response/DiffView.tsx
@@ -10,6 +10,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { X, ChevronUp, ChevronDown, EyeOff, Eye, GitCompare } from 'lucide-react'
 import { useTabsStore } from '@/stores/tabs'
+import { useCollectionsStore } from '@/stores/collections'
 import { cn } from '@/lib/utils'
 
 // ─── Diff algorithm ───────────────────────────────────────────────────────────
@@ -337,12 +338,13 @@ const METHOD_COLORS: Record<string, string> = {
 
 export function DiffPickerModal({ currentTabId, onConfirm, onCancel }: DiffPickerModalProps) {
   const tabs = useTabsStore((s) => s.tabs)
+  const activeWorkspaceId = useCollectionsStore((s) => s.activeWorkspaceId)
   const [pasteText, setPasteText] = useState('')
   const [mode, setMode] = useState<'tabs' | 'paste'>('tabs')
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 
   const candidateTabs = tabs.filter(
-    (t) => t.id !== currentTabId && t.response && !t.response.error,
+    (t) => (t.workspaceId ?? activeWorkspaceId) === activeWorkspaceId && t.id !== currentTabId && t.response && !t.response.error,
   )
 
   useEffect(() => {

--- a/frontend/src/components/workspace/WorkspacePanel.tsx
+++ b/frontend/src/components/workspace/WorkspacePanel.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Clock, Download, FolderOpen, LogIn, RefreshCw, Save, Shield, ShieldAlert, Trash2, Undo2, Upload } from 'lucide-react'
 import { useServerPort, serverUrl, sidecarFetch } from '@/lib/useServerPort'
-import { useCollectionsStore, migrateCollections } from '@/stores/collections'
+import { useCollectionsStore } from '@/stores/collections'
 import { useEnvironmentsStore } from '@/stores/environments'
 import { useSettingsStore } from '@/stores/settings'
 import { useTabsStore } from '@/stores/tabs'
@@ -25,19 +25,27 @@ export function WorkspacePanel() {
   const [flowDefinitions, setFlowDefinitions] = useState<SavedFlowDefinition[]>([])
   const fileInputRef = useRef<HTMLInputElement>(null)
 
-  const makeState = () => JSON.stringify({
-    version: 2,
-    savedAt: new Date().toISOString(),
-    openTabs: useTabsStore.getState().tabs,
-    activeTabId: useTabsStore.getState().activeTabId,
-    collections: useCollectionsStore.getState().collections,
-    environments: useEnvironmentsStore.getState().environments,
-    activeEnvId: useEnvironmentsStore.getState().activeEnvId,
-    settings: useSettingsStore.getState().settings,
-    websocket: (() => { try { const raw = localStorage.getItem('adomnia.websocket'); return raw ? JSON.parse(raw) : null } catch { return null } })(),
-    flows: flowDefinitions,
-    dockerLab: (() => { try { const raw = localStorage.getItem('adomnia.dockerlab.last'); return raw ? JSON.parse(raw) : null } catch { return null } })(),
-  }, null, 2)
+  const makeState = () => {
+    const collectionState = useCollectionsStore.getState()
+    const workspaceId = collectionState.activeWorkspaceId
+    const activeWorkspace = collectionState.workspaces.find((workspace) => workspace.id === workspaceId)
+    const workspaceTabs = useTabsStore.getState().tabs.filter((tab) => (tab.workspaceId ?? workspaceId) === workspaceId)
+    const activeTabId = useTabsStore.getState().activeTabId
+    return JSON.stringify({
+      version: 2,
+      savedAt: new Date().toISOString(),
+      workspace: activeWorkspace ? { id: activeWorkspace.id, name: activeWorkspace.name } : undefined,
+      openTabs: workspaceTabs,
+      activeTabId: workspaceTabs.some((tab) => tab.id === activeTabId) ? activeTabId : workspaceTabs[0]?.id ?? null,
+      collections: collectionState.collections,
+      environments: useEnvironmentsStore.getState().environments,
+      activeEnvId: useEnvironmentsStore.getState().activeEnvId,
+      settings: useSettingsStore.getState().settings,
+      websocket: (() => { try { const raw = localStorage.getItem('adomnia.websocket'); return raw ? JSON.parse(raw) : null } catch { return null } })(),
+      flows: flowDefinitions,
+      dockerLab: (() => { try { const raw = localStorage.getItem('adomnia.dockerlab.last'); return raw ? JSON.parse(raw) : null } catch { return null } })(),
+    }, null, 2)
+  }
 
   const api = useCallback(async (path: string, body?: unknown) => {
     const url = serverUrl(port, path)
@@ -178,8 +186,7 @@ export function WorkspacePanel() {
     if (!undoState) return
     const state = JSON.parse(undoState)
     if (Array.isArray(state.collections)) {
-      useCollectionsStore.setState({ collections: migrateCollections(state.collections), loaded: true })
-      useCollectionsStore.getState().save()
+      useCollectionsStore.getState().replaceCollections(state.collections)
     }
     if (Array.isArray(state.environments)) {
       useEnvironmentsStore.setState({ environments: state.environments, activeEnvId: state.activeEnvId ?? null, loaded: true })
@@ -236,7 +243,7 @@ export function WorkspacePanel() {
         <div className="p-4 border-b border-border-1 flex flex-col gap-3 shrink-0">
           <div className="flex items-center gap-2">
             <FolderOpen size={14} className="text-accent" />
-            <h2 className="text-xs font-semibold text-text-2">Saved workspaces</h2>
+            <h2 className="text-xs font-semibold text-text-2">Saved workspace snapshots</h2>
             <button onClick={refresh} className="ml-auto w-6 h-6 flex items-center justify-center text-text-4 hover:text-text-1 hover:bg-surface-2 rounded-md transition-colors" title="Refresh">
               <RefreshCw size={13} />
             </button>
@@ -348,8 +355,8 @@ export function WorkspacePanel() {
           {workspaces.length === 0 ? (
             <div className="flex flex-col items-center justify-center gap-2 py-12 text-center px-4">
               <FolderOpen size={24} className="text-text-4 opacity-40" />
-              <p className="text-xs text-text-4">No saved workspaces yet</p>
-              <p className="text-[10px] text-text-4">Type a name above and click Save</p>
+              <p className="text-xs text-text-4">No saved snapshots yet</p>
+              <p className="text-[10px] text-text-4">Save a point-in-time backup of the active workspace</p>
             </div>
           ) : (
             workspaces.map((ws) => (

--- a/frontend/src/hooks/useFileDrop.ts
+++ b/frontend/src/hooks/useFileDrop.ts
@@ -9,6 +9,7 @@ import { importCollectionsFromText } from '@/lib/collectionTransfer'
 import { routeGlobalDropFile } from '@/lib/globalFileRouter'
 import { saveFlowDefinitions } from '@/lib/flowStorage'
 import { safeSetItem } from '@/lib/safeLocalStorage'
+import type { Tab } from '@/lib/types'
 
 export interface DropFeedback {
   msg: string
@@ -87,11 +88,16 @@ export function useFileDrop(): FileDropResult {
             (parsed.version === 2 || parsed.format === 'adomnia-workspace')
           if (isWorkspace && parsed) {
             if (Array.isArray(parsed.openTabs)) {
-              useTabsStore.setState({ tabs: parsed.openTabs as never, activeTabId: (parsed.activeTabId as string | null) ?? (parsed.openTabs as {id:string}[])[0]?.id ?? null })
+              const workspaceId = useCollectionsStore.getState().activeWorkspaceId
+              const incomingTabs: Tab[] = (parsed.openTabs as Tab[]).map((tab) => ({ ...tab, workspaceId }))
+              const otherTabs = useTabsStore.getState().tabs.filter((tab) => tab.workspaceId !== workspaceId)
+              const importedActiveTabId = incomingTabs.some((tab) => tab.id === parsed.activeTabId)
+                ? parsed.activeTabId as string
+                : incomingTabs[0]?.id ?? null
+              useTabsStore.setState({ tabs: [...otherTabs, ...incomingTabs], activeTabId: importedActiveTabId })
             }
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            useCollectionsStore.setState({ collections: migrateCollections(parsed.collections as any[]), loaded: true })
-            useCollectionsStore.getState().save()
+            useCollectionsStore.getState().replaceCollections(migrateCollections(parsed.collections as any[]))
             if (Array.isArray(parsed.environments)) {
               useEnvironmentsStore.setState({ environments: parsed.environments as never, activeEnvId: (parsed.activeEnvId as string | null) ?? null, loaded: true })
               useEnvironmentsStore.getState().save()

--- a/frontend/src/lib/demoWorkspace.ts
+++ b/frontend/src/lib/demoWorkspace.ts
@@ -745,18 +745,13 @@ export function loadDefaultPostmanDemo(): boolean {
   if (!colStore.loaded || !envStore.loaded) return false
   if (colStore.collections.length > 0 || envStore.environments.length > 0) return false
 
-  useCollectionsStore.setState({
-    collections: [getDefaultPostmanDemoCollection()],
-    loaded: true,
-    loadError: false,
-  })
+  useCollectionsStore.getState().replaceCollections([getDefaultPostmanDemoCollection()])
   useEnvironmentsStore.setState({
     environments: [getDefaultPostmanDemoEnvironment()],
     activeEnvId: POSTMAN_DEMO_ENVIRONMENT.id,
     loaded: true,
     loadError: false,
   })
-  void useCollectionsStore.getState().save()
   void useEnvironmentsStore.getState().save()
   return true
 }

--- a/frontend/src/lib/storageSchemas.ts
+++ b/frontend/src/lib/storageSchemas.ts
@@ -9,7 +9,7 @@ export const STORAGE_SCHEMAS = {
   collections: {
     bucket: 'collections',
     item: 'all',
-    currentVersion: 1,
+    currentVersion: 2,
   },
   flows: {
     bucket: 'flows',

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -119,6 +119,14 @@ export interface Collection {
   _openapiSpec?: string
 }
 
+export interface CollectionWorkspace {
+  id: string
+  name: string
+  collections: Collection[]
+  createdAt: string
+  updatedAt: string
+}
+
 export interface EnvVariable {
   id: string
   key: string
@@ -156,6 +164,7 @@ export interface Tab {
   id: string
   request: RequestItem
   collectionId?: string
+  workspaceId?: string
   dirty: boolean
   response: ResponseData | null
   loading: boolean

--- a/frontend/src/lib/workspaceState.ts
+++ b/frontend/src/lib/workspaceState.ts
@@ -1,6 +1,6 @@
 import type { Collection, Environment, Tab } from '@/lib/types'
 import type { AppSettings } from '@/stores/settings'
-import { useCollectionsStore, migrateCollections } from '@/stores/collections'
+import { useCollectionsStore } from '@/stores/collections'
 import { useEnvironmentsStore } from '@/stores/environments'
 import { useSettingsStore } from '@/stores/settings'
 import { useTabsStore } from '@/stores/tabs'
@@ -8,6 +8,7 @@ import { saveFlowDefinitions, type SavedFlowDefinition } from '@/lib/flowStorage
 import { safeSetItem } from '@/lib/safeLocalStorage'
 
 export interface WorkspaceState {
+  workspace?: { id: string; name: string }
   openTabs?: Tab[]
   activeTabId?: string | null
   collections?: Collection[]
@@ -21,15 +22,20 @@ export interface WorkspaceState {
 
 export async function applyWorkspaceState(state: WorkspaceState): Promise<SavedFlowDefinition[] | undefined> {
   if (Array.isArray(state.openTabs)) {
+    const workspaceId = useCollectionsStore.getState().activeWorkspaceId
+    const workspaceTabs = state.openTabs.map((tab) => ({ ...tab, workspaceId }))
+    const otherTabs = useTabsStore.getState().tabs.filter((tab) => tab.workspaceId !== workspaceId)
+    const activeTabId = workspaceTabs.some((tab) => tab.id === state.activeTabId)
+      ? state.activeTabId ?? null
+      : workspaceTabs[0]?.id ?? null
     useTabsStore.setState({
-      tabs: state.openTabs,
-      activeTabId: state.activeTabId ?? state.openTabs[0]?.id ?? null,
+      tabs: [...otherTabs, ...workspaceTabs],
+      activeTabId,
     })
     useTabsStore.getState().save()
   }
   if (Array.isArray(state.collections)) {
-    useCollectionsStore.setState({ collections: migrateCollections(state.collections), loaded: true })
-    useCollectionsStore.getState().save()
+    useCollectionsStore.getState().replaceCollections(state.collections)
   }
   if (Array.isArray(state.environments)) {
     useEnvironmentsStore.setState({

--- a/frontend/src/stores/collections.test.ts
+++ b/frontend/src/stores/collections.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const storage = vi.hoisted(() => ({
+  get: vi.fn<(bucket: string, key: string) => Promise<string>>(),
+  put: vi.fn<(bucket: string, key: string, value: string) => Promise<void>>(),
+}))
+
+vi.mock('@/wailsjs/go/main/App', () => ({
+  StorageGet: storage.get,
+  StoragePut: storage.put,
+}))
+
+vi.mock('@/lib/storeSave', () => ({
+  debouncedSave: (_key: string, save: () => Promise<void>) => {
+    void save()
+  },
+}))
+
+import { DEFAULT_WORKSPACE_ID, useCollectionsStore } from '@/stores/collections'
+
+describe('collections workspaces', () => {
+  beforeEach(() => {
+    storage.get.mockReset()
+    storage.put.mockReset()
+    storage.put.mockResolvedValue()
+    useCollectionsStore.setState({
+      collections: [],
+      workspaces: [],
+      activeWorkspaceId: DEFAULT_WORKSPACE_ID,
+      loaded: false,
+      loadError: false,
+    })
+  })
+
+  it('migrates legacy collections into the default workspace', async () => {
+    storage.get.mockResolvedValue(JSON.stringify({
+      version: 1,
+      collections: [{ id: 'legacy-col', name: 'Legacy API', children: [] }],
+    }))
+
+    await useCollectionsStore.getState().load()
+
+    const state = useCollectionsStore.getState()
+    expect(state.activeWorkspaceId).toBe(DEFAULT_WORKSPACE_ID)
+    expect(state.workspaces).toHaveLength(1)
+    expect(state.workspaces[0].collections[0].name).toBe('Legacy API')
+    expect(state.collections[0].id).toBe('legacy-col')
+
+    const migrated = JSON.parse(storage.put.mock.calls[0][2])
+    expect(migrated.version).toBe(2)
+    expect(migrated.workspaces[0].collections[0].id).toBe('legacy-col')
+  })
+
+  it('moves collections between workspaces and restores the target collection list', () => {
+    useCollectionsStore.setState({
+      collections: [],
+      workspaces: [{
+        id: DEFAULT_WORKSPACE_ID,
+        name: 'Default Workspace',
+        collections: [],
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      }],
+      activeWorkspaceId: DEFAULT_WORKSPACE_ID,
+      loaded: true,
+      loadError: false,
+    })
+
+    const collection = useCollectionsStore.getState().addCollection('Payments')
+    const target = useCollectionsStore.getState().addWorkspace('Banking')
+    useCollectionsStore.getState().moveCollectionToWorkspace(collection.id, target.id)
+
+    expect(useCollectionsStore.getState().collections).toHaveLength(0)
+    expect(useCollectionsStore.getState().workspaces.find((workspace) => workspace.id === target.id)?.collections[0].name).toBe('Payments')
+
+    useCollectionsStore.getState().setActiveWorkspace(target.id)
+
+    expect(useCollectionsStore.getState().collections[0].id).toBe(collection.id)
+  })
+})

--- a/frontend/src/stores/collections.ts
+++ b/frontend/src/stores/collections.ts
@@ -1,9 +1,9 @@
 import { create } from 'zustand'
-import type { Collection, TreeNode, RequestItem, FolderItem, RequestBody } from '@/lib/types'
+import type { Collection, CollectionWorkspace, TreeNode, RequestItem, FolderItem, RequestBody } from '@/lib/types'
 import { uid, blankBody, blankKVRow, blankAuth } from '@/lib/types'
 import { StorageGet, StoragePut } from '@/wailsjs/go/main/App'
 import { debouncedSave } from '@/lib/storeSave'
-import { storageSchema, versionedEnvelope } from '@/lib/storageSchemas'
+import { storageSchema } from '@/lib/storageSchemas'
 
 const COLLECTIONS_SCHEMA = storageSchema('collections')
 const BUCKET = COLLECTIONS_SCHEMA.bucket
@@ -11,15 +11,24 @@ const KEY = COLLECTIONS_SCHEMA.item
 
 interface PersistedCollections {
   version: number
-  collections: Collection[]
+  activeWorkspaceId: string
+  workspaces: CollectionWorkspace[]
 }
 
 interface CollectionsState {
   collections: Collection[]
+  workspaces: CollectionWorkspace[]
+  activeWorkspaceId: string
   loaded: boolean
   loadError: boolean
   load: () => Promise<void>
   save: () => void
+  replaceCollections: (collections: Collection[]) => void
+  addWorkspace: (name: string) => CollectionWorkspace
+  renameWorkspace: (id: string, name: string) => void
+  deleteWorkspace: (id: string) => string | null
+  setActiveWorkspace: (id: string) => void
+  moveCollectionToWorkspace: (collectionId: string, targetWorkspaceId: string) => void
   addCollection: (name: string) => Collection
   deleteCollection: (id: string) => void
   renameCollection: (id: string, name: string) => void
@@ -33,6 +42,37 @@ interface CollectionsState {
   deleteNodes: (collectionId: string, nodeIds: string[]) => void
   duplicateNode: (collectionId: string, nodeId: string) => TreeNode | null
   reorderCollections: (fromId: string, toId: string) => void
+}
+
+export const DEFAULT_WORKSPACE_ID = 'workspace-default'
+const DEFAULT_WORKSPACE_NAME = 'Default Workspace'
+
+function makeWorkspace(name: string, collections: Collection[] = [], id = uid()): CollectionWorkspace {
+  const now = new Date().toISOString()
+  return { id, name, collections, createdAt: now, updatedAt: now }
+}
+
+function migrateWorkspaces(workspaces: CollectionWorkspace[]): CollectionWorkspace[] {
+  return workspaces.map((workspace) => ({
+    ...workspace,
+    name: workspace.name || 'Untitled Workspace',
+    collections: migrateCollections(Array.isArray(workspace.collections) ? workspace.collections : []),
+    createdAt: workspace.createdAt || new Date().toISOString(),
+    updatedAt: workspace.updatedAt || workspace.createdAt || new Date().toISOString(),
+  }))
+}
+
+function syncActiveWorkspace(
+  workspaces: CollectionWorkspace[],
+  activeWorkspaceId: string,
+  collections: Collection[],
+): CollectionWorkspace[] {
+  const now = new Date().toISOString()
+  return workspaces.map((workspace) => (
+    workspace.id === activeWorkspaceId
+      ? { ...workspace, collections, updatedAt: now }
+      : workspace
+  ))
 }
 
 function migrateBody(b: RequestBody): RequestBody {
@@ -162,6 +202,8 @@ function insertIntoTree(nodes: TreeNode[], parentId: string | null, item: TreeNo
 
 export const useCollectionsStore = create<CollectionsState>((set, get) => ({
   collections: [],
+  workspaces: [],
+  activeWorkspaceId: DEFAULT_WORKSPACE_ID,
   loaded: false,
   loadError: false,
 
@@ -171,28 +213,47 @@ export const useCollectionsStore = create<CollectionsState>((set, get) => ({
       if (raw) {
         const parsed = JSON.parse(raw)
         let collections: Collection[]
+        let workspaces: CollectionWorkspace[]
+        let activeWorkspaceId: string
         let needsVersionUpgrade = false
         if (Array.isArray(parsed)) {
           // Legacy format: bare array, no version envelope; migrate and upgrade.
           collections = migrateCollections(parsed)
+          workspaces = [makeWorkspace(DEFAULT_WORKSPACE_NAME, collections, DEFAULT_WORKSPACE_ID)]
+          activeWorkspaceId = DEFAULT_WORKSPACE_ID
           needsVersionUpgrade = true
         } else if (parsed && typeof parsed === 'object' && parsed.version !== undefined) {
-          const { version, collections: cols } = parsed as PersistedCollections
-          if (version < COLLECTIONS_SCHEMA.currentVersion) {
-            collections = migrateCollections(cols)
+          const version = Number(parsed.version)
+          if (version < 2 || !Array.isArray(parsed.workspaces)) {
+            collections = migrateCollections(Array.isArray(parsed.collections) ? parsed.collections : [])
+            workspaces = [makeWorkspace(DEFAULT_WORKSPACE_NAME, collections, DEFAULT_WORKSPACE_ID)]
+            activeWorkspaceId = DEFAULT_WORKSPACE_ID
             needsVersionUpgrade = true
           } else {
-            collections = cols
+            workspaces = migrateWorkspaces(parsed.workspaces as CollectionWorkspace[])
+            if (workspaces.length === 0) {
+              workspaces = [makeWorkspace(DEFAULT_WORKSPACE_NAME, [], DEFAULT_WORKSPACE_ID)]
+              needsVersionUpgrade = true
+            }
+            activeWorkspaceId = typeof parsed.activeWorkspaceId === 'string' && workspaces.some((workspace) => workspace.id === parsed.activeWorkspaceId)
+              ? parsed.activeWorkspaceId
+              : workspaces[0].id
+            if (activeWorkspaceId !== parsed.activeWorkspaceId) needsVersionUpgrade = true
+            collections = workspaces.find((workspace) => workspace.id === activeWorkspaceId)?.collections ?? []
           }
         } else {
           collections = []
+          workspaces = [makeWorkspace(DEFAULT_WORKSPACE_NAME, [], DEFAULT_WORKSPACE_ID)]
+          activeWorkspaceId = DEFAULT_WORKSPACE_ID
+          needsVersionUpgrade = true
         }
         // Persist the migrated data immediately so the next load sees the current
         // schema version and does NOT re-run migrations (acceptance: idempotent load).
         if (needsVersionUpgrade) {
           const upgraded: PersistedCollections = {
             version: COLLECTIONS_SCHEMA.currentVersion,
-            collections,
+            activeWorkspaceId,
+            workspaces,
           }
           try {
             await StoragePut(BUCKET, KEY, JSON.stringify(upgraded))
@@ -200,20 +261,109 @@ export const useCollectionsStore = create<CollectionsState>((set, get) => ({
             // Non-fatal: data is in memory; will be persisted on the next mutation.
           }
         }
-        set({ collections, loaded: true, loadError: false })
+        set({ collections, workspaces, activeWorkspaceId, loaded: true, loadError: false })
       } else {
-        set({ loaded: true, loadError: false })
+        const workspace = makeWorkspace(DEFAULT_WORKSPACE_NAME, [], DEFAULT_WORKSPACE_ID)
+        set({
+          collections: [],
+          workspaces: [workspace],
+          activeWorkspaceId: workspace.id,
+          loaded: true,
+          loadError: false,
+        })
       }
     } catch {
-      set({ loaded: true, loadError: true })
+      const workspace = makeWorkspace(DEFAULT_WORKSPACE_NAME, [], DEFAULT_WORKSPACE_ID)
+      set({
+        collections: [],
+        workspaces: [workspace],
+        activeWorkspaceId: workspace.id,
+        loaded: true,
+        loadError: true,
+      })
     }
   },
 
   save: () => {
     const s = get()
     if (!s.loaded || s.loadError) return
-    const persisted = versionedEnvelope(COLLECTIONS_SCHEMA, 'collections', s.collections) as unknown as PersistedCollections
+    const workspaces = syncActiveWorkspace(s.workspaces, s.activeWorkspaceId, s.collections)
+    set({ workspaces })
+    const persisted: PersistedCollections = {
+      version: COLLECTIONS_SCHEMA.currentVersion,
+      activeWorkspaceId: s.activeWorkspaceId,
+      workspaces,
+    }
     debouncedSave('collections', () => StoragePut(BUCKET, KEY, JSON.stringify(persisted)))
+  },
+
+  replaceCollections: (collections) => {
+    const migrated = migrateCollections(collections)
+    set((s) => ({
+      collections: migrated,
+      workspaces: syncActiveWorkspace(s.workspaces, s.activeWorkspaceId, migrated),
+    }))
+    get().save()
+  },
+
+  addWorkspace: (name) => {
+    const workspace = makeWorkspace(name.trim() || 'Untitled Workspace')
+    set((s) => ({ workspaces: [...s.workspaces, workspace] }))
+    get().save()
+    return workspace
+  },
+
+  renameWorkspace: (id, name) => {
+    const trimmed = name.trim()
+    if (!trimmed) return
+    set((s) => ({
+      workspaces: s.workspaces.map((workspace) => (
+        workspace.id === id ? { ...workspace, name: trimmed, updatedAt: new Date().toISOString() } : workspace
+      )),
+    }))
+    get().save()
+  },
+
+  deleteWorkspace: (id) => {
+    const state = get()
+    if (state.workspaces.length <= 1 || !state.workspaces.some((workspace) => workspace.id === id)) return null
+    const remaining = state.workspaces.filter((workspace) => workspace.id !== id)
+    const nextActiveId = state.activeWorkspaceId === id ? remaining[0].id : state.activeWorkspaceId
+    const nextCollections = remaining.find((workspace) => workspace.id === nextActiveId)?.collections ?? []
+    set({ workspaces: remaining, activeWorkspaceId: nextActiveId, collections: nextCollections })
+    get().save()
+    return nextActiveId
+  },
+
+  setActiveWorkspace: (id) => {
+    const state = get()
+    if (id === state.activeWorkspaceId) return
+    const target = state.workspaces.find((workspace) => workspace.id === id)
+    if (!target) return
+    const synced = syncActiveWorkspace(state.workspaces, state.activeWorkspaceId, state.collections)
+    set({ workspaces: synced, activeWorkspaceId: id, collections: target.collections })
+    get().save()
+  },
+
+  moveCollectionToWorkspace: (collectionId, targetWorkspaceId) => {
+    const state = get()
+    if (targetWorkspaceId === state.activeWorkspaceId) return
+    const collection = state.collections.find((item) => item.id === collectionId)
+    if (!collection || !state.workspaces.some((workspace) => workspace.id === targetWorkspaceId)) return
+    const remaining = state.collections.filter((item) => item.id !== collectionId)
+    set((s) => ({
+      collections: remaining,
+      workspaces: s.workspaces.map((workspace) => {
+        if (workspace.id === s.activeWorkspaceId) {
+          return { ...workspace, collections: remaining, updatedAt: new Date().toISOString() }
+        }
+        if (workspace.id === targetWorkspaceId) {
+          return { ...workspace, collections: [...workspace.collections, collection], updatedAt: new Date().toISOString() }
+        }
+        return workspace
+      }),
+    }))
+    get().save()
   },
 
   addCollection: (name) => {

--- a/frontend/src/stores/tabs.ts
+++ b/frontend/src/stores/tabs.ts
@@ -4,6 +4,7 @@ import { uid, blankRequest } from '@/lib/types'
 import { StorageGet, StoragePut } from '@/wailsjs/go/main/App'
 import { debouncedSave } from '@/lib/storeSave'
 import { useSettingsStore } from '@/stores/settings'
+import { useCollectionsStore } from '@/stores/collections'
 
 const BUCKET = 'tabs'
 const KEY = 'session-v1'
@@ -39,6 +40,9 @@ interface TabsState {
   loadError: boolean
   load: () => Promise<void>
   save: () => void
+  activateWorkspace: (workspaceId: string) => void
+  deleteWorkspaceTabs: (workspaceId: string) => void
+  moveCollectionTabs: (collectionId: string, targetWorkspaceId: string) => void
   openTab: (request: RequestItem, collectionId?: string) => void
   closeTab: (id: string) => void
   closeTabsToRight: (id: string) => void
@@ -68,7 +72,19 @@ function shouldSaveResponses(): boolean {
 }
 
 function cleanLoadedTab(tab: Tab): Tab {
-  return { ...tab, loading: false }
+  return {
+    ...tab,
+    workspaceId: tab.workspaceId ?? useCollectionsStore.getState().activeWorkspaceId,
+    loading: false,
+  }
+}
+
+function activeWorkspaceId(): string {
+  return useCollectionsStore.getState().activeWorkspaceId
+}
+
+function belongsToWorkspace(tab: Tab, workspaceId = activeWorkspaceId()): boolean {
+  return (tab.workspaceId ?? workspaceId) === workspaceId
 }
 
 function isHistoryEntry(value: RequestHistoryEntry | ResponseData): value is RequestHistoryEntry {
@@ -126,9 +142,9 @@ export const useTabsStore = create<TabsState>((set, get) => ({
       const restoredTabs = settings.general.restoreTabsOnStartup
         ? (parsed.tabs ?? []).map(cleanLoadedTab)
         : []
-      const activeTabId = restoredTabs.some((t) => t.id === parsed.activeTabId)
+      const activeTabId = restoredTabs.some((t) => t.id === parsed.activeTabId && belongsToWorkspace(t))
         ? parsed.activeTabId
-        : restoredTabs[0]?.id ?? null
+        : restoredTabs.find((tab) => belongsToWorkspace(tab))?.id ?? null
       set({
         tabs: restoredTabs,
         activeTabId,
@@ -155,8 +171,54 @@ export const useTabsStore = create<TabsState>((set, get) => ({
     debouncedSave('tabs', () => StoragePut(BUCKET, KEY, JSON.stringify(payload)))
   },
 
+  activateWorkspace: (workspaceId) => {
+    set((s) => ({
+      activeTabId: s.tabs.find((tab) => belongsToWorkspace(tab, workspaceId))?.id ?? null,
+    }))
+    get().save()
+  },
+
+  deleteWorkspaceTabs: (workspaceId) => {
+    set((s) => {
+      const tabs = s.tabs.filter((tab) => tab.workspaceId !== workspaceId)
+      const activeTabId = tabs.some((tab) => tab.id === s.activeTabId)
+        ? s.activeTabId
+        : tabs.find((tab) => belongsToWorkspace(tab))?.id ?? null
+      return {
+        tabs,
+        activeTabId,
+        viewStateByTabId: retainViewStates(s.viewStateByTabId, tabs),
+      }
+    })
+    get().save()
+  },
+
+  moveCollectionTabs: (collectionId, targetWorkspaceId) => {
+    const sourceWorkspaceId = activeWorkspaceId()
+    set((s) => {
+      const tabs = s.tabs.map((tab) => (
+        tab.collectionId === collectionId && belongsToWorkspace(tab, sourceWorkspaceId)
+          ? { ...tab, workspaceId: targetWorkspaceId }
+          : tab
+      ))
+      const activeTabMoved = s.tabs.some((tab) => (
+        tab.id === s.activeTabId &&
+        tab.collectionId === collectionId &&
+        belongsToWorkspace(tab, sourceWorkspaceId)
+      ))
+      return {
+        tabs,
+        activeTabId: activeTabMoved
+          ? tabs.find((tab) => belongsToWorkspace(tab) && tab.collectionId !== collectionId)?.id ?? null
+          : s.activeTabId,
+      }
+    })
+    get().save()
+  },
+
   openTab: (request, collectionId) => {
-    const existing = get().tabs.find((t) => t.request.id === request.id)
+    const workspaceId = activeWorkspaceId()
+    const existing = get().tabs.find((t) => t.request.id === request.id && belongsToWorkspace(t, workspaceId))
     if (existing) {
       set({ activeTabId: existing.id })
       get().save()
@@ -166,6 +228,7 @@ export const useTabsStore = create<TabsState>((set, get) => ({
       id: uid(),
       request: { ...request },
       collectionId,
+      workspaceId,
       dirty: false,
       response: null,
       loading: false,
@@ -179,8 +242,10 @@ export const useTabsStore = create<TabsState>((set, get) => ({
       const filtered = s.tabs.filter((t) => t.id !== id)
       let activeTabId = s.activeTabId
       if (activeTabId === id) {
-        const idx = s.tabs.findIndex((t) => t.id === id)
-        activeTabId = filtered[Math.min(idx, filtered.length - 1)]?.id ?? null
+        const visibleTabs = s.tabs.filter((tab) => belongsToWorkspace(tab))
+        const idx = visibleTabs.findIndex((t) => t.id === id)
+        const remainingVisibleTabs = filtered.filter((tab) => belongsToWorkspace(tab))
+        activeTabId = remainingVisibleTabs[Math.min(idx, remainingVisibleTabs.length - 1)]?.id ?? null
       }
       return { tabs: filtered, activeTabId }
     })
@@ -190,13 +255,16 @@ export const useTabsStore = create<TabsState>((set, get) => ({
 
   closeTabsToRight: (id) => {
     set((s) => {
-      const idx = s.tabs.findIndex((t) => t.id === id)
+      const workspaceTabs = s.tabs.filter((tab) => belongsToWorkspace(tab))
+      const idx = workspaceTabs.findIndex((t) => t.id === id)
       if (idx === -1) return s
-      const filtered = s.tabs.filter((_, i) => i <= idx)
+      const removeIds = new Set(workspaceTabs.slice(idx + 1).map((tab) => tab.id))
+      const filtered = s.tabs.filter((tab) => !removeIds.has(tab.id))
       const activeTabStillExists = filtered.some((t) => t.id === s.activeTabId)
+      const remainingWorkspaceTabs = filtered.filter((tab) => belongsToWorkspace(tab))
       return {
         tabs: filtered,
-        activeTabId: activeTabStillExists ? s.activeTabId : filtered[filtered.length - 1]?.id ?? null,
+        activeTabId: activeTabStillExists ? s.activeTabId : remainingWorkspaceTabs[remainingWorkspaceTabs.length - 1]?.id ?? null,
         viewStateByTabId: retainViewStates(s.viewStateByTabId, filtered),
       }
     })
@@ -205,13 +273,15 @@ export const useTabsStore = create<TabsState>((set, get) => ({
 
   closeTabsToLeft: (id) => {
     set((s) => {
-      const idx = s.tabs.findIndex((t) => t.id === id)
+      const workspaceTabs = s.tabs.filter((tab) => belongsToWorkspace(tab))
+      const idx = workspaceTabs.findIndex((t) => t.id === id)
       if (idx === -1) return s
-      const filtered = s.tabs.filter((_, i) => i >= idx)
+      const removeIds = new Set(workspaceTabs.slice(0, idx).map((tab) => tab.id))
+      const filtered = s.tabs.filter((tab) => !removeIds.has(tab.id))
       const activeTabStillExists = filtered.some((t) => t.id === s.activeTabId)
       return {
         tabs: filtered,
-        activeTabId: activeTabStillExists ? s.activeTabId : filtered[0]?.id ?? null,
+        activeTabId: activeTabStillExists ? s.activeTabId : filtered.find((tab) => belongsToWorkspace(tab))?.id ?? null,
         viewStateByTabId: retainViewStates(s.viewStateByTabId, filtered),
       }
     })
@@ -246,6 +316,7 @@ export const useTabsStore = create<TabsState>((set, get) => ({
     const tab: Tab = {
       id: uid(),
       request,
+      workspaceId: activeWorkspaceId(),
       dirty: false,
       response: null,
       loading: false,
@@ -265,6 +336,7 @@ export const useTabsStore = create<TabsState>((set, get) => ({
     const newTab: Tab = {
       id: uid(),
       request: newRequest,
+      workspaceId: src.workspaceId ?? activeWorkspaceId(),
       dirty: true,
       response: null,
       loading: false,
@@ -321,6 +393,7 @@ export const useTabsStore = create<TabsState>((set, get) => ({
     const tab: Tab = {
       id: uid(),
       request,
+      workspaceId: activeWorkspaceId(),
       dirty: false,
       response: cloneForHistory(entry.response),
       loading: false,


### PR DESCRIPTION
## Overview

  This PR introduces first-class multi-collection workspaces to adOmnia.

  Users can now organize collections into independent local workspaces, switch between them directly from the API Workspace sidebar, and
  retain separate open tabs for each workspace.

  ## Motivation

  Previously, all collections shared one global context. This made it difficult to separate unrelated projects, clients, or
  environments.

  The new workspace model improves organization while preserving adOmnia’s local-first workflow and backward compatibility.

  ## Changes

  ### Workspace Management

  - Added workspace selector to the collections sidebar.
  - Added create, rename, switch, and delete actions.
  - Added the active workspace indicator to the status bar.
  - Prevented deletion of the final remaining workspace.
  - Added warnings when deleting workspaces containing collections or unsaved tabs.

  ### Collections

  - Each workspace now owns an independent set of collections.
  - Added the ability to move a collection between workspaces from its context menu.
  - Imports and demo collections are added to the active workspace.

  ### Tabs

  - Open tabs are associated with their workspace.
  - Switching workspaces restores the relevant tabs.
  - Tab closing, comparison, recent requests, command palette, and dashboard metrics are scoped to the active workspace.
  - Moving a collection also moves its associated tabs.

  ### Persistence and Compatibility

  - Upgraded the collections storage schema from version 1 to 2.
  - Existing collections are automatically migrated into Default Workspace.
  - Migration preserves existing collection data.
  - Workspace snapshots and exports now include only the active workspace’s collections and tabs.

  ### Documentation and Tests

  - Updated the README and feature catalog.
  - Added tests covering:
      - Legacy collection migration.
      - Moving collections between workspaces.
      - Restoring collections after workspace switching.

  ## User Experience

  1. Open the API Workspace.
  2. Use the workspace selector above the collections tree.
  3. Create or switch workspace using the adjacent controls.
  4. Create or import collections into the active workspace.
  5. Move a collection through its context menu using Move to workspace.

  ## Backward Compatibility

  Existing users do not need to take any action.

  On first load, existing collections are automatically placed inside a workspace named Default Workspace.

  ## Verification

  - [x] npm run build
  - [x] npm test - 10 tests passed
  - [x] go test ./internal/storage ./internal/sidecar
  - [x] git diff --check
  - [x] Existing collection storage migration tested
  - [x] Collection movement between workspaces tested

  ## Screenshots
<img width="1426" height="901" alt="image" src="https://github.com/user-attachments/assets/7f319dfa-f014-487f-ae64-e777f5811256" />

  ## Checklist

  - [x] The change follows existing project patterns.
  - [x] Existing user data remains readable.
  - [x] The feature remains local-first.
  - [x] Documentation has been updated.
  - [x] Relevant tests have been added.
  - [x] Frontend production build passes.
  - [x] No unrelated generated files are included.
