### PR TITLE
fix missing request bodies and "No file detected" on linux

### DIFF
--- a/app.go
+++ b/app.go
@@ -32,6 +32,36 @@ type App struct {
 	browserDebug *BrowserDebug
 }
 
+type DroppedFileData struct {
+	Name        string `json:"name"`
+	Path        string `json:"path"`
+	Text        string `json:"text,omitempty"`
+	BytesBase64 string `json:"bytesBase64,omitempty"`
+}
+
+const maxDroppedFileBytes = 50 * 1024 * 1024
+
+func isSupportedDroppedFile(name string) bool {
+	lower := strings.ToLower(name)
+	switch {
+	case strings.HasSuffix(lower, ".class"),
+		strings.HasSuffix(lower, ".pdf"),
+		strings.HasSuffix(lower, ".har"),
+		strings.HasSuffix(lower, ".wsdl"),
+		strings.HasSuffix(lower, ".mmd"),
+		strings.HasSuffix(lower, ".mermaid"),
+		strings.HasSuffix(lower, ".tex"),
+		strings.HasSuffix(lower, ".json"),
+		strings.HasSuffix(lower, ".yaml"),
+		strings.HasSuffix(lower, ".yml"),
+		strings.HasSuffix(lower, ".adomnia"),
+		strings.HasSuffix(lower, ".bru"):
+		return true
+	default:
+		return false
+	}
+}
+
 func NewApp() *App {
 	return &App{}
 }
@@ -78,6 +108,47 @@ func (a *App) GetServerPort() int {
 
 func (a *App) GetSidecarToken() string {
 	return sidecar.Token()
+}
+
+func (a *App) ReadDroppedFiles(paths []string) (string, error) {
+	result := make([]DroppedFileData, 0, len(paths))
+	for _, rawPath := range paths {
+		path := strings.TrimSpace(rawPath)
+		if path == "" {
+			continue
+		}
+		cleaned := filepath.Clean(path)
+		info, err := os.Stat(cleaned)
+		if err != nil {
+			return "", fmt.Errorf("could not read dropped file %q: %w", filepath.Base(cleaned), err)
+		}
+		if info.IsDir() {
+			return "", fmt.Errorf("%s is a folder; drop a supported file instead", filepath.Base(cleaned))
+		}
+		if info.Size() > maxDroppedFileBytes {
+			return "", fmt.Errorf("%s is too large to import from drag and drop", filepath.Base(cleaned))
+		}
+		if !isSupportedDroppedFile(info.Name()) {
+			return "", fmt.Errorf("%s is not a supported drag-and-drop file type", filepath.Base(cleaned))
+		}
+		data, err := os.ReadFile(cleaned)
+		if err != nil {
+			return "", fmt.Errorf("could not read dropped file %q: %w", filepath.Base(cleaned), err)
+		}
+		entry := DroppedFileData{Name: filepath.Base(cleaned), Path: cleaned}
+		lower := strings.ToLower(entry.Name)
+		if strings.HasSuffix(lower, ".pdf") || strings.HasSuffix(lower, ".class") {
+			entry.BytesBase64 = base64.StdEncoding.EncodeToString(data)
+		} else {
+			entry.Text = string(data)
+		}
+		result = append(result, entry)
+	}
+	out, err := json.Marshal(result)
+	if err != nil {
+		return "", fmt.Errorf("failed to serialize dropped files: %w", err)
+	}
+	return string(out), nil
 }
 
 func (a *App) CompareFolders(left, right string, maxFileMB int64) (string, error) {

--- a/frontend/src/hooks/useFileDrop.ts
+++ b/frontend/src/hooks/useFileDrop.ts
@@ -1,10 +1,11 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import type React from 'react'
 import { useCollectionsStore, migrateCollections } from '@/stores/collections'
 import { useEnvironmentsStore } from '@/stores/environments'
 import { useTabsStore } from '@/stores/tabs'
 import { useSettingsStore } from '@/stores/settings'
 import { useAppStore } from '@/stores/app'
+import { ReadDroppedFiles } from '@/wailsjs/go/main/App'
 import { importCollectionsFromText } from '@/lib/collectionTransfer'
 import { routeGlobalDropFile } from '@/lib/globalFileRouter'
 import { saveFlowDefinitions } from '@/lib/flowStorage'
@@ -29,10 +30,42 @@ export interface FileDropResult {
   handlers: FileDropHandlers
 }
 
+interface DroppedFileData {
+  name: string
+  path: string
+  text?: string
+  bytesBase64?: string
+}
+
+function filesFromDataTransfer(dataTransfer: DataTransfer): File[] {
+  const files = Array.from(dataTransfer.files ?? [])
+  if (files.length > 0) return files
+
+  return Array.from(dataTransfer.items ?? [])
+    .filter((item) => item.kind === 'file')
+    .map((item) => item.getAsFile())
+    .filter((file): file is File => Boolean(file))
+}
+
+function base64ToArrayBuffer(value: string): ArrayBuffer {
+  const binary = window.atob(value)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i)
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+}
+
+function fileFromDroppedData(entry: DroppedFileData): File {
+  const payload = entry.bytesBase64 ? base64ToArrayBuffer(entry.bytesBase64) : entry.text ?? ''
+  return new File([payload], entry.name || entry.path.split(/[\\/]/).pop() || 'dropped-file')
+}
+
 export function useFileDrop(): FileDropResult {
   const [dragOver, setDragOver] = useState(false)
   const [dropFeedback, setDropFeedback] = useState<DropFeedback | null>(null)
   const dragCounter = useRef(0)
+  const noFileTimer = useRef<number | null>(null)
+  const suppressNativeDropUntil = useRef(0)
+  const suppressBrowserDropUntil = useRef(0)
 
   const importCollection = useCollectionsStore((s) => s.importCollection)
   const setActiveRail    = useAppStore((s) => s.setActiveRail)
@@ -42,87 +75,132 @@ export function useFileDrop(): FileDropResult {
     setTimeout(() => setDropFeedback(null), 3500)
   }, [])
 
+  const clearNoFileTimer = useCallback(() => {
+    if (noFileTimer.current !== null) {
+      window.clearTimeout(noFileTimer.current)
+      noFileTimer.current = null
+    }
+  }, [])
+
+  const importDroppedFiles = useCallback(async (files: File[]) => {
+    let totalImported = 0; let workspaceImported = false
+    const errors: string[] = []; let routedTool = false
+
+    for (const file of files) {
+      try {
+        const routed = await routeGlobalDropFile(file)
+        if (routed.kind !== 'collection') {
+          if (routedTool || totalImported > 0) { errors.push(`${file.name}: drop tool files one at a time.`); continue }
+          useAppStore.getState().queueFileImport(routed)
+          const target = routed.kind === 'har' ? 'har' : routed.kind === 'wsdl' ? 'soap' : routed.kind === 'mermaid' ? 'mermaid' : routed.kind === 'latex' ? 'latex' : routed.kind === 'pdf' ? 'pdfeditor' : 'powertools'
+          const label = routed.kind === 'har' ? 'HAR Viewer' : routed.kind === 'wsdl' ? 'SOAP Studio' : routed.kind === 'mermaid' ? 'Mermaid Studio' : routed.kind === 'latex' ? 'LaTeX Studio' : routed.kind === 'pdf' ? 'PDF Editor' : 'Class File Inspector'
+          setActiveRail(target)
+          showFeedback(`${file.name} opened in ${label}.`, true)
+          routedTool = true; continue
+        }
+        const text = routed.text
+        let parsed: Record<string, unknown> | null = null
+        try { parsed = JSON.parse(text) as Record<string, unknown> } catch { /* not JSON */ }
+        const isWorkspace = parsed !== null && Array.isArray(parsed.collections) &&
+          (parsed.version === 2 || parsed.format === 'adomnia-workspace')
+        if (isWorkspace && parsed) {
+          if (Array.isArray(parsed.openTabs)) {
+            const workspaceId = useCollectionsStore.getState().activeWorkspaceId
+            const incomingTabs: Tab[] = (parsed.openTabs as Tab[]).map((tab) => ({ ...tab, workspaceId }))
+            const otherTabs = useTabsStore.getState().tabs.filter((tab) => tab.workspaceId !== workspaceId)
+            const importedActiveTabId = incomingTabs.some((tab) => tab.id === parsed.activeTabId)
+              ? parsed.activeTabId as string
+              : incomingTabs[0]?.id ?? null
+            useTabsStore.setState({ tabs: [...otherTabs, ...incomingTabs], activeTabId: importedActiveTabId })
+          }
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          useCollectionsStore.getState().replaceCollections(migrateCollections(parsed.collections as any[]))
+          if (Array.isArray(parsed.environments)) {
+            useEnvironmentsStore.setState({ environments: parsed.environments as never, activeEnvId: (parsed.activeEnvId as string | null) ?? null, loaded: true })
+            useEnvironmentsStore.getState().save()
+          }
+          if (parsed.settings) { useSettingsStore.setState({ settings: parsed.settings as never, loaded: true }); useSettingsStore.getState().save() }
+          if (Array.isArray(parsed.flows)) await saveFlowDefinitions(parsed.flows)
+          if (parsed.dockerLab) safeSetItem('adomnia.dockerlab.last', JSON.stringify(parsed.dockerLab))
+          if (parsed.websocket) safeSetItem('adomnia.websocket', JSON.stringify(parsed.websocket))
+          totalImported += (parsed.collections as unknown[]).length; workspaceImported = true
+        } else {
+          const result = importCollectionsFromText(text)
+          result.collections.forEach((c) => importCollection(c))
+          totalImported += result.collections.length
+        }
+      } catch (err: unknown) { errors.push(`${file.name}: ${err instanceof Error ? err.message : 'Import failed'}`) }
+    }
+    if (!routedTool) {
+      if (totalImported > 0) {
+        setActiveRail('collections')
+        const label = workspaceImported ? 'Workspace imported' : `Imported ${totalImported} collection${totalImported > 1 ? 's' : ''}`
+        showFeedback(`${label} successfully.`, true)
+      } else { showFeedback(errors[0] ?? 'Import failed.', false) }
+    }
+  }, [importCollection, setActiveRail, showFeedback])
+
+  const importDroppedPaths = useCallback(async (paths: string[]) => {
+    if (!paths.length) return
+    clearNoFileTimer()
+    suppressBrowserDropUntil.current = Date.now() + 1200
+    setDragOver(false); dragCounter.current = 0
+    try {
+      const raw = await ReadDroppedFiles(paths)
+      const entries = JSON.parse(raw) as DroppedFileData[]
+      const files = entries.map(fileFromDroppedData)
+      if (!files.length) { showFeedback('No file detected.', false); return }
+      await importDroppedFiles(files)
+    } catch (err) {
+      showFeedback(err instanceof Error ? err.message : 'Drop import failed.', false)
+    }
+  }, [clearNoFileTimer, importDroppedFiles, showFeedback])
+
+  useEffect(() => {
+    if (!window.runtime?.OnFileDrop) return undefined
+    window.runtime.OnFileDrop((_x, _y, paths) => {
+      if (Date.now() < suppressNativeDropUntil.current) return
+      void importDroppedPaths(paths)
+    }, false)
+    return () => window.runtime?.OnFileDropOff?.()
+  }, [importDroppedPaths])
+
   const handleDragEnter = useCallback((e: React.DragEvent<HTMLDivElement>) => {
-    e.preventDefault(); e.stopPropagation()
+    e.preventDefault()
     dragCounter.current++
-    if (e.dataTransfer.types.includes('Files')) setDragOver(true)
+    if (Array.from(e.dataTransfer.types).includes('Files')) setDragOver(true)
   }, [])
 
   const handleDragLeave = useCallback((e: React.DragEvent<HTMLDivElement>) => {
-    e.preventDefault(); e.stopPropagation()
+    e.preventDefault()
     dragCounter.current--
     if (dragCounter.current <= 0) { dragCounter.current = 0; setDragOver(false) }
   }, [])
 
   const handleDragOver = useCallback((e: React.DragEvent<HTMLDivElement>) => {
-    e.preventDefault(); e.stopPropagation()
+    e.preventDefault()
   }, [])
 
   const handleDrop = useCallback(
     async (e: React.DragEvent<HTMLDivElement>) => {
-      e.preventDefault(); e.stopPropagation()
+      e.preventDefault()
       setDragOver(false); dragCounter.current = 0
 
-      const files = Array.from(e.dataTransfer.files)
-      if (!files.length) { showFeedback('No file detected.', false); return }
-
-      let totalImported = 0; let workspaceImported = false
-      const errors: string[] = []; let routedTool = false
-
-      for (const file of files) {
-        try {
-          const routed = await routeGlobalDropFile(file)
-          if (routed.kind !== 'collection') {
-            if (routedTool || totalImported > 0) { errors.push(`${file.name}: drop tool files one at a time.`); continue }
-            useAppStore.getState().queueFileImport(routed)
-            const target = routed.kind === 'har' ? 'har' : routed.kind === 'wsdl' ? 'soap' : routed.kind === 'mermaid' ? 'mermaid' : routed.kind === 'latex' ? 'latex' : routed.kind === 'pdf' ? 'pdfeditor' : 'powertools'
-            const label = routed.kind === 'har' ? 'HAR Viewer' : routed.kind === 'wsdl' ? 'SOAP Studio' : routed.kind === 'mermaid' ? 'Mermaid Studio' : routed.kind === 'latex' ? 'LaTeX Studio' : routed.kind === 'pdf' ? 'PDF Editor' : 'Class File Inspector'
-            setActiveRail(target)
-            showFeedback(`${file.name} opened in ${label}.`, true)
-            routedTool = true; continue
-          }
-          const text = routed.text
-          let parsed: Record<string, unknown> | null = null
-          try { parsed = JSON.parse(text) as Record<string, unknown> } catch { /* not JSON */ }
-          const isWorkspace = parsed !== null && Array.isArray(parsed.collections) &&
-            (parsed.version === 2 || parsed.format === 'adomnia-workspace')
-          if (isWorkspace && parsed) {
-            if (Array.isArray(parsed.openTabs)) {
-              const workspaceId = useCollectionsStore.getState().activeWorkspaceId
-              const incomingTabs: Tab[] = (parsed.openTabs as Tab[]).map((tab) => ({ ...tab, workspaceId }))
-              const otherTabs = useTabsStore.getState().tabs.filter((tab) => tab.workspaceId !== workspaceId)
-              const importedActiveTabId = incomingTabs.some((tab) => tab.id === parsed.activeTabId)
-                ? parsed.activeTabId as string
-                : incomingTabs[0]?.id ?? null
-              useTabsStore.setState({ tabs: [...otherTabs, ...incomingTabs], activeTabId: importedActiveTabId })
-            }
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            useCollectionsStore.getState().replaceCollections(migrateCollections(parsed.collections as any[]))
-            if (Array.isArray(parsed.environments)) {
-              useEnvironmentsStore.setState({ environments: parsed.environments as never, activeEnvId: (parsed.activeEnvId as string | null) ?? null, loaded: true })
-              useEnvironmentsStore.getState().save()
-            }
-            if (parsed.settings) { useSettingsStore.setState({ settings: parsed.settings as never, loaded: true }); useSettingsStore.getState().save() }
-            if (Array.isArray(parsed.flows)) await saveFlowDefinitions(parsed.flows)
-            if (parsed.dockerLab) safeSetItem('adomnia.dockerlab.last', JSON.stringify(parsed.dockerLab))
-            if (parsed.websocket) safeSetItem('adomnia.websocket', JSON.stringify(parsed.websocket))
-            totalImported += (parsed.collections as unknown[]).length; workspaceImported = true
-          } else {
-            const result = importCollectionsFromText(text)
-            result.collections.forEach((c) => importCollection(c))
-            totalImported += result.collections.length
-          }
-        } catch (err: unknown) { errors.push(`${file.name}: ${err instanceof Error ? err.message : 'Import failed'}`) }
+      const files = filesFromDataTransfer(e.dataTransfer)
+      if (!files.length) {
+        clearNoFileTimer()
+        noFileTimer.current = window.setTimeout(() => {
+          showFeedback('No file detected.', false)
+          noFileTimer.current = null
+        }, 700)
+        return
       }
-      if (!routedTool) {
-        if (totalImported > 0) {
-          setActiveRail('collections')
-          const label = workspaceImported ? 'Workspace imported' : `Imported ${totalImported} collection${totalImported > 1 ? 's' : ''}`
-          showFeedback(`${label} successfully.`, true)
-        } else { showFeedback(errors[0] ?? 'Import failed.', false) }
-      }
+      if (Date.now() < suppressBrowserDropUntil.current) return
+      suppressNativeDropUntil.current = Date.now() + 1200
+      clearNoFileTimer()
+      await importDroppedFiles(files)
     },
-    [importCollection, setActiveRail, showFeedback],
+    [clearNoFileTimer, importDroppedFiles, showFeedback],
   )
 
   return { dragOver, dropFeedback, handlers: { onDragEnter: handleDragEnter, onDragLeave: handleDragLeave, onDragOver: handleDragOver, onDrop: handleDrop } }

--- a/frontend/src/lib/openapi.test.ts
+++ b/frontend/src/lib/openapi.test.ts
@@ -132,4 +132,123 @@ paths:
       expect.objectContaining({ key: 'verbose', value: 'true' }),
     ]))
   })
+
+  it('generates a raw JSON body from Swagger 2 YAML body parameters', () => {
+    const collections = parseOpenAPI(`
+swagger: '2.0'
+info:
+  title: Legacy Store API
+  version: 1.0.0
+host: api.example.test
+basePath: /v1
+schemes: [https]
+paths:
+  /pets:
+    post:
+      summary: Create pet
+      consumes:
+        - application/json
+      parameters:
+        - name: pet
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/Pet'
+      responses:
+        '201':
+          description: Created
+definitions:
+  Pet:
+    type: object
+    required: [name]
+    properties:
+      name:
+        type: string
+        example: Fido
+      age:
+        type: integer
+        default: 3
+`)
+
+    const request = collections[0].children[0]
+    if (request.type !== 'request') throw new Error('Expected imported node to be a request')
+    expect(request.url).toBe('https://api.example.test/v1/pets')
+    expect(request.bodies[0]).toMatchObject({
+      type: 'raw',
+      lang: 'json',
+    })
+    expect(JSON.parse(request.bodies[0].raw)).toEqual({ name: 'Fido', age: 3 })
+  })
+
+  it('generates form bodies from Swagger 2 YAML formData parameters', () => {
+    const collections = parseOpenAPI(`
+swagger: '2.0'
+info:
+  title: Upload API
+  version: 1.0.0
+paths:
+  /avatar:
+    post:
+      summary: Upload avatar
+      consumes:
+        - multipart/form-data
+      parameters:
+        - name: userId
+          in: formData
+          required: true
+          type: string
+          default: u_123
+        - name: avatar
+          in: formData
+          required: true
+          type: file
+      responses:
+        '200':
+          description: OK
+`)
+
+    const request = collections[0].children[0]
+    if (request.type !== 'request') throw new Error('Expected imported node to be a request')
+    expect(request.bodies[0].type).toBe('formdata')
+    expect(request.bodies[0].form).toEqual(expect.arrayContaining([
+      expect.objectContaining({ key: 'userId', value: 'u_123', enabled: true }),
+      expect.objectContaining({ key: 'avatar', value: '', enabled: true }),
+    ]))
+  })
+
+  it('resolves reusable OpenAPI 3 requestBody refs and plural examples', () => {
+    const collections = parseOpenAPI(`
+openapi: 3.0.3
+info:
+  title: Orders API
+  version: 1.0.0
+paths:
+  /orders:
+    post:
+      summary: Create order
+      requestBody:
+        $ref: '#/components/requestBodies/CreateOrder'
+      responses:
+        '201':
+          description: Created
+components:
+  requestBodies:
+    CreateOrder:
+      content:
+        application/json:
+          examples:
+            standard:
+              value:
+                sku: book-1
+                quantity: 2
+`)
+
+    const request = collections[0].children[0]
+    if (request.type !== 'request') throw new Error('Expected imported node to be a request')
+    expect(request.bodies[0]).toMatchObject({
+      type: 'raw',
+      lang: 'json',
+    })
+    expect(JSON.parse(request.bodies[0].raw)).toEqual({ sku: 'book-1', quantity: 2 })
+  })
 })

--- a/frontend/src/lib/openapi.ts
+++ b/frontend/src/lib/openapi.ts
@@ -10,30 +10,47 @@ function tryParseYaml(text: string): unknown {
   try { return parseYamlLenient(t) } catch { throw new Error('Invalid OpenAPI spec format (must be JSON or YAML)') }
 }
 
+interface OpenAPIMediaType {
+  schema?: unknown
+  example?: unknown
+  examples?: unknown
+}
+
+interface OpenAPIRequestBody {
+  $ref?: string
+  required?: boolean
+  content?: Record<string, OpenAPIMediaType>
+}
+
+interface OpenAPIParameter {
+  name: string
+  in: 'query' | 'header' | 'path' | 'cookie' | 'body' | 'formData'
+  required?: boolean
+  schema?: OpenAPISchemaObject
+  description?: string
+  example?: unknown
+  default?: unknown
+  type?: string
+  format?: string
+  enum?: unknown[]
+}
+
 interface OpenAPIOperation {
   operationId?: string
   summary?: string
   description?: string
   tags?: string[]
   security?: Array<Record<string, string[]>>
-  parameters?: Array<{
-    name: string
-    in: 'query' | 'header' | 'path' | 'cookie'
-    required?: boolean
-    schema?: { type?: string; default?: unknown }
-    description?: string
-    example?: unknown
-  }>
-  requestBody?: {
-    content?: Record<string, { schema?: unknown; example?: unknown }>
-  }
+  parameters?: OpenAPIParameter[]
+  requestBody?: OpenAPIRequestBody
+  consumes?: string[]
   responses?: Record<string, unknown>
 }
 
-type OpenAPIParameter = NonNullable<OpenAPIOperation['parameters']>[number]
 type OpenAPIPathItem = Partial<Record<HttpMethodKey, OpenAPIOperation>> & {
   $ref?: string
   parameters?: OpenAPIParameter[]
+  consumes?: string[]
 }
 type HttpMethodKey = 'get' | 'post' | 'put' | 'patch' | 'delete' | 'head' | 'options'
 
@@ -67,7 +84,8 @@ interface OpenAPISchemaObject {
 }
 
 interface OpenAPISpec {
-  openapi: string
+  openapi?: string
+  swagger?: string
   info: { title: string; version?: string; description?: string }
   servers?: Array<{
     url: string
@@ -76,42 +94,72 @@ interface OpenAPISpec {
   }>
   security?: Array<Record<string, string[]>>
   paths?: Record<string, OpenAPIPathItem>
+  host?: string
+  basePath?: string
+  schemes?: string[]
+  consumes?: string[]
   components?: {
     securitySchemes?: Record<string, SecurityScheme>
     schemas?: Record<string, OpenAPISchemaObject>
+    requestBodies?: Record<string, OpenAPIRequestBody>
   }
+  definitions?: Record<string, OpenAPISchemaObject>
   tags?: Array<{ name: string; description?: string }>
 }
 
-function resolveRef(ref: string, schemas: Record<string, OpenAPISchemaObject> | undefined): OpenAPISchemaObject | undefined {
-  if (!ref.startsWith('#/components/schemas/') || !schemas) return undefined
-  return schemas[ref.slice('#/components/schemas/'.length)]
+interface SchemaRegistry {
+  components?: Record<string, OpenAPISchemaObject>
+  definitions?: Record<string, OpenAPISchemaObject>
 }
 
-function schemaToExample(schema: OpenAPISchemaObject | undefined, schemas: Record<string, OpenAPISchemaObject> | undefined, depth = 0): unknown {
+function resolveSchemaRef(ref: string, registry: SchemaRegistry | undefined): OpenAPISchemaObject | undefined {
+  if (ref.startsWith('#/components/schemas/')) {
+    return registry?.components?.[ref.slice('#/components/schemas/'.length)]
+  }
+  if (ref.startsWith('#/definitions/')) {
+    return registry?.definitions?.[ref.slice('#/definitions/'.length)]
+  }
+  return undefined
+}
+
+function resolveRequestBodyRef(ref: string, requestBodies: Record<string, OpenAPIRequestBody> | undefined): OpenAPIRequestBody | undefined {
+  if (!ref.startsWith('#/components/requestBodies/') || !requestBodies) return undefined
+  return requestBodies[ref.slice('#/components/requestBodies/'.length)]
+}
+
+function schemaToExample(schema: OpenAPISchemaObject | undefined, registry: SchemaRegistry | undefined, depth = 0): unknown {
   if (!schema || depth > 8) return undefined
   if (schema.$ref) {
-    const resolved = resolveRef(schema.$ref, schemas)
-    return resolved ? schemaToExample(resolved, schemas, depth) : undefined
+    const resolved = resolveSchemaRef(schema.$ref, registry)
+    return resolved ? schemaToExample(resolved, registry, depth + 1) : undefined
   }
   if (schema.example !== undefined) return schema.example
   if (schema.default !== undefined) return schema.default
 
-  const merged = mergeCompositeSchema(schema, schemas, depth)
+  const merged = mergeCompositeSchema(schema, registry, depth)
   if (merged) return merged
+
+  if (schema.properties && !schema.type) {
+    const obj: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(schema.properties)) {
+      const val = schemaToExample(v, registry, depth + 1)
+      if (val !== undefined) obj[k] = val
+    }
+    return obj
+  }
 
   switch (schema.type) {
     case 'object': {
       if (!schema.properties) return {}
       const obj: Record<string, unknown> = {}
       for (const [k, v] of Object.entries(schema.properties)) {
-        const val = schemaToExample(v, schemas, depth + 1)
+        const val = schemaToExample(v, registry, depth + 1)
         if (val !== undefined) obj[k] = val
       }
       return obj
     }
     case 'array': {
-      const item = schemaToExample(schema.items, schemas, depth + 1)
+      const item = schemaToExample(schema.items, registry, depth + 1)
       return item !== undefined ? [item] : []
     }
     case 'string':
@@ -131,29 +179,82 @@ function schemaToExample(schema: OpenAPISchemaObject | undefined, schemas: Recor
   }
 }
 
-function mergeCompositeSchema(schema: OpenAPISchemaObject, schemas: Record<string, OpenAPISchemaObject> | undefined, depth: number): unknown {
+function mergeCompositeSchema(schema: OpenAPISchemaObject, registry: SchemaRegistry | undefined, depth: number): unknown {
   const composite = schema.allOf ?? schema.anyOf ?? schema.oneOf
   if (!composite?.length) return undefined
   const merged: Record<string, unknown> = {}
   for (const sub of composite) {
-    const val = schemaToExample(sub, schemas, depth + 1)
+    const val = schemaToExample(sub, registry, depth + 1)
     if (val && typeof val === 'object' && !Array.isArray(val)) Object.assign(merged, val)
   }
   return Object.keys(merged).length > 0 ? merged : undefined
 }
 
-function getExample(body: OpenAPIOperation['requestBody'], schemas?: Record<string, OpenAPISchemaObject>): string | undefined {
-  if (!body?.content) return undefined
-  for (const ct of Object.keys(body.content)) {
-    const c = body.content[ct]
-    if (c?.example) return typeof c.example === 'string' ? c.example : JSON.stringify(c.example, null, 2)
-    // Fall back to generating an example from the schema
-    if (c?.schema) {
-      const s = c.schema as OpenAPISchemaObject
-      const generated = schemaToExample(s, schemas)
-      if (generated !== undefined) return JSON.stringify(generated, null, 2)
-    }
+function exampleFromExamples(examples: unknown): unknown {
+  if (!examples || typeof examples !== 'object' || Array.isArray(examples)) return undefined
+  const first = Object.values(examples as Record<string, unknown>)[0]
+  if (first && typeof first === 'object' && !Array.isArray(first) && 'value' in first) {
+    return (first as { value?: unknown }).value
   }
+  return first
+}
+
+function stringifyBodyExample(value: unknown, lang: RequestBody['lang']): string {
+  if (typeof value === 'string') return value
+  if (lang === 'json') return JSON.stringify(value, null, 2)
+  return String(value ?? '')
+}
+
+function mediaTypePriority(contentType: string): number {
+  const ct = contentType.toLowerCase()
+  if (ct.includes('json')) return 0
+  if (ct.includes('x-www-form-urlencoded')) return 1
+  if (ct.includes('multipart/form-data')) return 2
+  if (ct.includes('xml')) return 3
+  if (ct.includes('text')) return 4
+  return 5
+}
+
+function pickContentEntry(content: Record<string, OpenAPIMediaType>): [string, OpenAPIMediaType] | undefined {
+  return Object.entries(content).sort(([a], [b]) => mediaTypePriority(a) - mediaTypePriority(b))[0]
+}
+
+function langFromContentType(contentType: string): RequestBody['lang'] {
+  const ct = contentType.toLowerCase()
+  if (ct.includes('xml')) return 'xml'
+  if (ct.includes('html')) return 'html'
+  if (ct.includes('javascript')) return 'javascript'
+  if (ct.includes('text')) return 'text'
+  return 'json'
+}
+
+function valueFromSchemaOrParam(schema: OpenAPISchemaObject | undefined, param: OpenAPIParameter | undefined, registry: SchemaRegistry): string {
+  const value = param?.example
+    ?? param?.default
+    ?? schema?.example
+    ?? schema?.default
+    ?? (schema?.enum?.length ? schema.enum[0] : undefined)
+    ?? (param?.enum?.length ? param.enum[0] : undefined)
+    ?? schemaToExample(schema, registry)
+  return value === undefined ? '' : String(value)
+}
+
+function formRowsFromSchema(schema: OpenAPISchemaObject | undefined, registry: SchemaRegistry): KVRow[] {
+  const resolved = schema?.$ref ? resolveSchemaRef(schema.$ref, registry) ?? schema : schema
+  const props = resolved?.properties ?? {}
+  return Object.entries(props).map(([key, prop]) => ({
+    id: uid(),
+    key,
+    value: valueFromSchemaOrParam(prop, undefined, registry),
+    enabled: resolved?.required?.includes(key) ?? false,
+  }))
+}
+
+function getMediaExample(media: OpenAPIMediaType, registry: SchemaRegistry): unknown {
+  if (media.example !== undefined) return media.example
+  const example = exampleFromExamples(media.examples)
+  if (example !== undefined) return example
+  if (media.schema) return schemaToExample(media.schema as OpenAPISchemaObject, registry)
   return undefined
 }
 
@@ -208,12 +309,94 @@ function resolveServerUrl(server: NonNullable<OpenAPISpec['servers']>[number]): 
   return url.replace(/\/$/, '')
 }
 
-function ctFromSchema(body: OpenAPIOperation['requestBody']): 'json' | 'xml' | 'text' {
-  if (!body?.content) return 'json'
-  const cts = Object.keys(body.content)
-  if (cts.some((ct) => ct.includes('xml'))) return 'xml'
-  if (cts.some((ct) => ct.includes('text'))) return 'text'
-  return 'json'
+function swaggerBaseUrl(spec: OpenAPISpec): string {
+  if (!spec.host) return ''
+  const scheme = spec.schemes?.[0] ?? 'https'
+  const basePath = spec.basePath && spec.basePath !== '/' ? spec.basePath : ''
+  return `${scheme}://${spec.host}${basePath}`.replace(/\/$/, '')
+}
+
+function buildBodiesFromOpenAPIRequestBody(
+  body: OpenAPIRequestBody | undefined,
+  requestBodies: Record<string, OpenAPIRequestBody> | undefined,
+  registry: SchemaRegistry,
+): RequestBody[] | undefined {
+  const resolved = body?.$ref ? resolveRequestBodyRef(body.$ref, requestBodies) : body
+  if (!resolved?.content) return undefined
+
+  const picked = pickContentEntry(resolved.content)
+  if (!picked) return undefined
+
+  const [contentType, media] = picked
+  const lower = contentType.toLowerCase()
+  const schema = media.schema as OpenAPISchemaObject | undefined
+
+  if (lower.includes('x-www-form-urlencoded') || lower.includes('multipart/form-data')) {
+    return [{
+      id: uid(),
+      name: 'Body 1',
+      type: lower.includes('multipart/form-data') ? 'formdata' : 'urlencoded',
+      raw: '',
+      lang: 'json',
+      form: formRowsFromSchema(schema, registry),
+    }]
+  }
+
+  const lang = langFromContentType(contentType)
+  const example = getMediaExample(media, registry)
+  return [{
+    id: uid(),
+    name: 'Body 1',
+    type: 'raw',
+    raw: example === undefined ? '' : stringifyBodyExample(example, lang),
+    lang,
+    form: [],
+  }]
+}
+
+function buildBodiesFromSwaggerParameters(
+  parameters: OpenAPIParameter[] | undefined,
+  consumes: string[] | undefined,
+  registry: SchemaRegistry,
+): RequestBody[] | undefined {
+  if (!parameters?.length) return undefined
+
+  const formParams = parameters.filter((param) => param.in === 'formData')
+  if (formParams.length > 0) {
+    const isMultipart = consumes?.some((ct) => ct.toLowerCase().includes('multipart/form-data')) ?? false
+    return [{
+      id: uid(),
+      name: 'Body 1',
+      type: isMultipart ? 'formdata' : 'urlencoded',
+      raw: '',
+      lang: 'json',
+      form: formParams.map((param) => ({
+        id: uid(),
+        key: param.name,
+        value: valueFromSchemaOrParam(param.schema, param, registry),
+        enabled: param.required ?? false,
+      })),
+    }]
+  }
+
+  const bodyParam = parameters.find((param) => param.in === 'body')
+  if (!bodyParam) return undefined
+
+  const contentType = consumes?.[0] ?? 'application/json'
+  const lang = langFromContentType(contentType)
+  const example = bodyParam.example
+    ?? bodyParam.schema?.example
+    ?? bodyParam.schema?.default
+    ?? schemaToExample(bodyParam.schema, registry)
+
+  return [{
+    id: uid(),
+    name: 'Body 1',
+    type: 'raw',
+    raw: example === undefined ? '' : stringifyBodyExample(example, lang),
+    lang,
+    form: [],
+  }]
 }
 
 const HTTP_METHODS: HttpMethodKey[] = ['get', 'post', 'put', 'patch', 'delete', 'head', 'options']
@@ -255,14 +438,18 @@ function buildUnresolvedRefOperation(path: string, ref: string): OpenAPIOperatio
 export function parseOpenAPI(raw: string): Collection[] {
   const spec = tryParseYaml(raw) as OpenAPISpec
 
-  if (!spec.openapi) throw new Error('Not a valid OpenAPI spec: missing "openapi" field')
+  const isSwagger2 = typeof spec.swagger === 'string' && spec.swagger.startsWith('2')
+  if (!spec.openapi && !isSwagger2) throw new Error('Not a valid OpenAPI spec: missing "openapi" or Swagger 2.0 "swagger" field')
   if (!spec.paths) throw new Error('No paths found in OpenAPI spec')
 
   const schemes = spec.components?.securitySchemes
-  const schemas = spec.components?.schemas
+  const schemaRegistry: SchemaRegistry = {
+    components: spec.components?.schemas,
+    definitions: spec.definitions,
+  }
   const globalSecurity = spec.security
   const server = spec.servers?.[0]
-  const baseUrl = server ? resolveServerUrl(server) : ''
+  const baseUrl = isSwagger2 ? swaggerBaseUrl(spec) : (server ? resolveServerUrl(server) : '')
   // Global auth used as fallback when an operation has no security override
   const globalAuth = inferAuth(globalSecurity ?? (schemes ? [Object.fromEntries(Object.keys(schemes).map(k => [k, []]))] : undefined), schemes)
 
@@ -317,18 +504,10 @@ export function parseOpenAPI(raw: string): Collection[] {
       let bodies: RequestBody[] = [blankBody()]
       let activeBodyIdx = 0
 
-      if (op.requestBody) {
-        const ct = ctFromSchema(op.requestBody)
-        const ex = getExample(op.requestBody, schemas)
-        bodies = [{
-          id: uid(),
-          name: 'Body 1',
-          type: ex ? 'raw' : 'none',
-          raw: ex ?? '',
-          lang: ct,
-          form: [],
-        }]
-      }
+      const importedBodies = isSwagger2
+        ? buildBodiesFromSwaggerParameters(parameters, op.consumes ?? pathItem.consumes ?? spec.consumes, schemaRegistry)
+        : buildBodiesFromOpenAPIRequestBody(op.requestBody, spec.components?.requestBodies, schemaRegistry)
+      if (importedBodies) bodies = importedBodies
 
       // Collect any x- vendor extension fields so they survive a round-trip export
       const xExtensions: Record<string, unknown> = {}

--- a/frontend/src/wails-window.d.ts
+++ b/frontend/src/wails-window.d.ts
@@ -21,6 +21,7 @@ interface WailsGoMain {
     ClearDevLogs: () => Promise<void>
     CompareFolders: (left: string, right: string, maxFileMB: number) => Promise<string>
     ReadFolderDiffFile: (scanID: string, path: string, maxBytes: number) => Promise<string>
+    ReadDroppedFiles: (paths: string[]) => Promise<string>
     RecordFrontendLog: (level: string, message: string) => Promise<void>
     ListLogFiles: () => Promise<Array<{ name: string; size: number; modTime: string }>>
     ReadLogFile: (filename: string) => Promise<string>
@@ -183,4 +184,8 @@ interface LabOutput {
 
 interface Window {
   go: { main: WailsGoMain }
+  runtime?: {
+    OnFileDrop?: (callback: (x: number, y: number, paths: string[]) => void, useDropTarget: boolean) => void
+    OnFileDropOff?: () => void
+  }
 }

--- a/frontend/src/wailsjs/go/main/App.ts
+++ b/frontend/src/wailsjs/go/main/App.ts
@@ -54,6 +54,10 @@ export function ReadFolderDiffFile(scanID: string, path: string, maxBytes: numbe
   return (window['go']['main']['App'] as unknown as Record<string, (a: string, b: string, c: number) => Promise<string>>)['ReadFolderDiffFile'](scanID, path, maxBytes)
 }
 
+export function ReadDroppedFiles(paths: string[]): Promise<string> {
+  return (window['go']['main']['App'] as unknown as Record<string, (a: string[]) => Promise<string>>)['ReadDroppedFiles'](paths)
+}
+
 export function SelectFolder(title: string): Promise<string> {
   return window['go']['main']['App']['SelectFolder'](title)
 }

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -36,6 +36,8 @@ export function LoadSettings():Promise<string>;
 
 export function OpenDevLogsFolder():Promise<void>;
 
+export function ReadDroppedFiles(arg1:Array<string>):Promise<string>;
+
 export function ReadFolderDiffFile(arg1:string,arg2:string,arg3:number):Promise<string>;
 
 export function ReadLogFile(arg1:string):Promise<string>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -70,6 +70,10 @@ export function OpenDevLogsFolder() {
   return window['go']['main']['App']['OpenDevLogsFolder']();
 }
 
+export function ReadDroppedFiles(arg1) {
+  return window['go']['main']['App']['ReadDroppedFiles'](arg1);
+}
+
 export function ReadFolderDiffFile(arg1, arg2, arg3) {
   return window['go']['main']['App']['ReadFolderDiffFile'](arg1, arg2, arg3);
 }

--- a/main.go
+++ b/main.go
@@ -92,6 +92,9 @@ func main() {
 			WebviewUserDataPath:               dataDir(),
 			Theme:                             windows.Dark,
 		},
+		DragAndDrop: &options.DragAndDrop{
+			EnableFileDrop: true,
+		},
 		Frameless: isAppChrome(startupWindowChrome),
 	}
 	applyPlatformOptions(appOptions)


### PR DESCRIPTION
## Summary

  This PR fixes two OpenAPI/YAML import issues in adOmnia:

  - Fixes missing request bodies when importing YAML/OpenAPI specs.
  - Fixes drag-and-drop YAML import on Linux/WebKitGTK, where drops could show No file detected.

  ## Changes

  ### 1. Generate request bodies from imported YAML specs

  The OpenAPI importer now correctly creates adOmnia request bodies from more real-world spec shapes:

  - Swagger/OpenAPI 2 parameters with in: body
  - Swagger/OpenAPI 2 formData parameters
  - OpenAPI 3 reusable components.requestBodies
  - OpenAPI 3 examples
  - Schema refs from both:
      - #/components/schemas/...
      - #/definitions/...

  This resolves cases where imported YAML files created requests, but the body tab stayed empty or set to none.

  ### 2. Fix Linux drag-and-drop import

  On Linux/WebKitGTK, browser dataTransfer.files can be empty even when a file was dropped. The previous handler relied only on that browser file list, so dropping a
  YAML file could show:

  No file detected.

  The fix enables Wails native file-drop handling and adds a safe fallback path:

  - Enables Wails DragAndDrop.EnableFileDrop.
  - Registers OnFileDrop without requiring a Wails CSS drop target.
  - Removes event propagation blocking that prevented Wails from seeing the drop.
  - Adds backend ReadDroppedFiles() for dropped local files.
  - Restricts backend reading to supported import file types.
  - Reuses the existing global import router so YAML files follow the same OpenAPI import flow.

