### PR TITLE
feat: redesign responsive settings layout

### DIFF
--- a/frontend/src/components/settings/SettingsFields.tsx
+++ b/frontend/src/components/settings/SettingsFields.tsx
@@ -1,6 +1,12 @@
 import { useState } from 'react'
 import { Eye, EyeOff } from 'lucide-react'
 
+const fieldRowClass = 'grid min-w-0 grid-cols-[minmax(0,1fr)_minmax(220px,320px)] items-center gap-x-8 gap-y-2 px-2 py-3 max-lg:grid-cols-[minmax(0,1fr)_minmax(200px,280px)] max-md:grid-cols-1'
+const fieldCopyClass = 'min-w-0'
+const fieldLabelClass = 'text-xs font-medium text-text-1'
+const fieldDescriptionClass = 'mt-0.5 text-[10px] leading-relaxed text-text-4'
+const fieldControlClass = 'h-8 w-full min-w-0 rounded border border-border-2 bg-surface-2 px-3 text-xs text-text-1 outline-none focus:border-accent'
+
 export function Toggle({
   label,
   desc,
@@ -13,16 +19,16 @@ export function Toggle({
   onChange: (v: boolean) => void
 }) {
   return (
-    <label className="flex items-center justify-between py-2 px-1 cursor-pointer group">
-      <div>
-        <div className="text-xs text-text-1">{label}</div>
-        <div className="text-[10px] text-text-4">{desc}</div>
+    <label className={`${fieldRowClass} cursor-pointer group`}>
+      <div className={fieldCopyClass}>
+        <div className={fieldLabelClass}>{label}</div>
+        <div className={fieldDescriptionClass}>{desc}</div>
       </div>
       <input
         type="checkbox"
         checked={checked}
         onChange={(e) => onChange(e.target.checked)}
-        className="w-4 h-4 accent-accent rounded"
+        className="h-4 w-4 justify-self-end rounded accent-accent max-md:justify-self-start"
       />
     </label>
   )
@@ -41,16 +47,19 @@ export function Select({
   options: { value: string; label: string }[]
   onChange: (v: string) => void
 }) {
+  const selectedLabel = options.find((option) => option.value === value)?.label
+
   return (
-    <label className="flex items-center justify-between py-2 px-1">
-      <div>
-        <div className="text-xs text-text-1">{label}</div>
-        <div className="text-[10px] text-text-4">{desc}</div>
+    <label className={fieldRowClass}>
+      <div className={fieldCopyClass}>
+        <div className={fieldLabelClass}>{label}</div>
+        <div className={fieldDescriptionClass}>{desc}</div>
       </div>
       <select
         value={value}
+        title={selectedLabel}
         onChange={(e) => onChange(e.target.value)}
-        className="h-7 px-2 bg-surface-2 border border-border-2 rounded text-xs text-text-1 focus:border-accent outline-none max-w-[160px]"
+        className={`${fieldControlClass} !pr-9`}
       >
         {options.map((o) => (
           <option key={o.value} value={o.value}>
@@ -78,10 +87,10 @@ export function NumberInput({
   onChange: (v: number) => void
 }) {
   return (
-    <label className="flex items-center justify-between py-2 px-1">
-      <div>
-        <div className="text-xs text-text-1">{label}</div>
-        <div className="text-[10px] text-text-4">{desc}</div>
+    <label className={fieldRowClass}>
+      <div className={fieldCopyClass}>
+        <div className={fieldLabelClass}>{label}</div>
+        <div className={fieldDescriptionClass}>{desc}</div>
       </div>
       <input
         type="number"
@@ -91,7 +100,7 @@ export function NumberInput({
         onChange={(e) =>
           onChange(Math.min(max, Math.max(min, Number(e.target.value) || min)))
         }
-        className="w-24 h-7 px-2 bg-surface-2 border border-border-2 rounded text-xs text-text-1 focus:border-accent outline-none"
+        className={`${fieldControlClass} w-32 justify-self-end max-md:justify-self-start`}
       />
     </label>
   )
@@ -111,17 +120,17 @@ export function TextInput({
   onChange: (v: string) => void
 }) {
   return (
-    <label className="flex items-center justify-between py-2 px-1">
-      <div className="flex-1 mr-3">
-        <div className="text-xs text-text-1">{label}</div>
-        <div className="text-[10px] text-text-4">{desc}</div>
+    <label className={fieldRowClass}>
+      <div className={fieldCopyClass}>
+        <div className={fieldLabelClass}>{label}</div>
+        <div className={fieldDescriptionClass}>{desc}</div>
       </div>
       <input
         type="text"
         value={value}
         placeholder={placeholder}
         onChange={(e) => onChange(e.target.value)}
-        className="w-48 h-7 px-2 bg-surface-2 border border-border-2 rounded text-xs text-text-1 focus:border-accent outline-none"
+        className={fieldControlClass}
       />
     </label>
   )
@@ -142,18 +151,18 @@ export function PasswordInput({
 }) {
   const [show, setShow] = useState(false)
   return (
-    <label className="flex items-center justify-between py-2 px-1">
-      <div className="flex-1 mr-3">
-        <div className="text-xs text-text-1">{label}</div>
-        <div className="text-[10px] text-text-4">{desc}</div>
+    <label className={fieldRowClass}>
+      <div className={fieldCopyClass}>
+        <div className={fieldLabelClass}>{label}</div>
+        <div className={fieldDescriptionClass}>{desc}</div>
       </div>
-      <div className="relative">
+      <div className="relative min-w-0">
         <input
           type={show ? 'text' : 'password'}
           value={value}
           placeholder={placeholder}
           onChange={(e) => onChange(e.target.value)}
-          className="w-48 h-7 pl-2 pr-7 bg-surface-2 border border-border-2 rounded text-xs text-text-1 focus:border-accent outline-none"
+          className={`${fieldControlClass} pr-9`}
         />
         <button
           type="button"
@@ -184,17 +193,17 @@ export function TextAreaInput({
   onChange: (v: string) => void
 }) {
   return (
-    <label className="flex flex-col gap-1 py-2 px-1">
-      <div>
-        <div className="text-xs text-text-1">{label}</div>
-        <div className="text-[10px] text-text-4">{desc}</div>
+    <label className={`${fieldRowClass} items-start`}>
+      <div className={fieldCopyClass}>
+        <div className={fieldLabelClass}>{label}</div>
+        <div className={fieldDescriptionClass}>{desc}</div>
       </div>
       <textarea
         value={value}
         placeholder={placeholder}
         rows={rows}
         onChange={(e) => onChange(e.target.value)}
-        className="w-full px-2 py-1 bg-surface-2 border border-border-2 rounded text-xs text-text-1 focus:border-accent outline-none resize-y"
+        className="min-h-20 w-full min-w-0 resize-y rounded border border-border-2 bg-surface-2 px-3 py-2 text-xs text-text-1 outline-none focus:border-accent"
       />
     </label>
   )

--- a/frontend/src/components/settings/SettingsLayout.tsx
+++ b/frontend/src/components/settings/SettingsLayout.tsx
@@ -3,16 +3,16 @@ import { cn } from '@/lib/utils'
 
 export function SectionHeader({ title, subtitle }: { title: string; subtitle: string }) {
   return (
-    <div className="mb-3 pb-2 border-b border-border-1">
-      <h2 className="text-sm font-semibold text-text-1">{title}</h2>
-      <p className="text-[10px] text-text-4 mt-0.5">{subtitle}</p>
+    <div className="mb-5 border-b border-border-1 pb-4">
+      <h2 className="text-base font-semibold tracking-tight text-text-1">{title}</h2>
+      <p className="mt-1 max-w-3xl text-[11px] leading-relaxed text-text-4">{subtitle}</p>
     </div>
   )
 }
 
 export function SettingsCard({ children, className }: { children: ReactNode; className?: string }) {
   return (
-    <div className={cn('bg-surface-1 border border-border-2 rounded-md p-3 mb-3', className)}>
+    <div className={cn('mb-4 overflow-hidden rounded-lg border border-border-2 bg-surface-1 px-3', className)}>
       <div className="flex flex-col divide-y divide-border-1">{children}</div>
     </div>
   )
@@ -20,7 +20,7 @@ export function SettingsCard({ children, className }: { children: ReactNode; cla
 
 export function DangerZone({ children }: { children: ReactNode }) {
   return (
-    <div className="border border-status-err/30 rounded-md p-3 mb-3 bg-status-err/5">
+    <div className="mb-4 overflow-hidden rounded-lg border border-status-err/30 bg-status-err/5 px-3">
       <div className="flex flex-col divide-y divide-border-1">{children}</div>
     </div>
   )

--- a/frontend/src/components/settings/SettingsPanel.tsx
+++ b/frontend/src/components/settings/SettingsPanel.tsx
@@ -298,18 +298,18 @@ export function SettingsPanel({ initialSection = 'general' }: { initialSection?:
       ]
 
   return (
-    <div className="flex h-full">
+    <div className="flex h-full min-w-0 bg-surface-0">
       {/* Sidebar */}
-      <div className="w-52 border-r border-border-1 py-3 px-2 flex flex-col gap-0.5 overflow-y-auto">
+      <aside className="flex w-60 shrink-0 flex-col gap-0.5 overflow-y-auto border-r border-border-1 bg-surface-1/35 px-3 py-4 max-lg:w-52">
         {/* Search */}
-        <div className="relative mb-2">
-          <Search size={12} className="absolute left-2 top-1/2 -translate-y-1/2 text-text-4" />
+        <div className="relative mb-3">
+          <Search size={13} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-text-4" />
           <input
             type="text"
             placeholder="Search settings..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            className="w-full h-7 pl-7 pr-2 bg-surface-2 border border-border-2 rounded text-xs text-text-1 placeholder:text-text-4 focus:border-accent outline-none"
+            className="h-8 w-full rounded-md border border-border-2 bg-surface-2 pl-8 pr-2 text-xs text-text-1 outline-none placeholder:text-text-4 focus:border-accent"
           />
         </div>
         {sectionDefs.map((sec) => (
@@ -317,14 +317,14 @@ export function SettingsPanel({ initialSection = 'general' }: { initialSection?:
             key={sec.id}
             onClick={() => setSection(sec.id)}
             className={cn(
-              'text-left px-3 py-1.5 rounded text-xs transition-colors flex items-center gap-2',
+              'flex min-h-8 w-full items-center gap-2.5 rounded-md border px-2.5 py-1.5 text-left text-xs transition-colors',
               section === sec.id
-                ? 'bg-surface-2 text-text-1'
-                : 'text-text-3 hover:text-text-1 hover:bg-surface-2'
+                ? 'border-border-2 bg-surface-2 text-text-1 shadow-sm'
+                : 'border-transparent text-text-3 hover:bg-surface-2 hover:text-text-1'
             )}
           >
-            {sec.icon}
-            <span className="flex-1">{sec.label}</span>
+            <span className={cn('shrink-0', section === sec.id ? 'text-accent' : 'text-text-4')}>{sec.icon}</span>
+            <span className="min-w-0 flex-1 truncate">{sec.label}</span>
             {settingsModified && section === sec.id && (
               <span className="w-1.5 h-1.5 rounded-full bg-accent flex-shrink-0" />
             )}
@@ -333,10 +333,16 @@ export function SettingsPanel({ initialSection = 'general' }: { initialSection?:
         {sectionDefs.length === 0 && (
           <p className="px-3 py-2 text-[10px] leading-relaxed text-text-4">No setting matches "{search.trim()}".</p>
         )}
-      </div>
+      </aside>
 
       {/* Content */}
-      <div className={cn('flex-1 overflow-y-auto p-4', section === 'workspace' ? 'max-w-none' : 'max-w-xl')}>
+      <div className="min-w-0 flex-1 overflow-y-auto">
+        <div className={cn(
+          'w-full',
+          section === 'workspace'
+            ? 'h-full p-4'
+            : 'mx-auto max-w-[1240px] px-8 pb-16 pt-6 max-lg:px-5 max-md:px-4'
+        )}>
         {/* General */}
         {section === 'general' && (
           <>
@@ -1124,6 +1130,7 @@ export function SettingsPanel({ initialSection = 'general' }: { initialSection?:
         {section === 'ai' && (
           <AISettings />
         )}
+        </div>
       </div>
       <ConfirmDialog
         open={confirmDisableTabRestore}


### PR DESCRIPTION
## Summary

  Redesign the Settings panel with a wider, responsive desktop layout.

  - Expand the settings content area to use the available workspace.
  - Introduce a clearer split view between navigation and content.
  - Align labels, descriptions, and controls using responsive rows.
  - Increase dropdown width and prevent text from overlapping the native arrow.
  - Improve cards, section headers, spacing, and narrow-window behavior.

  ## Product Impact

  Settings are easier to scan and use on large displays, without leaving most of the workspace empty.

  Long theme and window-titlebar values remain readable, including on Linux/WebKitGTK, while controls automatically stack when the available width is limited.

  
<img width="2488" height="1532" alt="Schermata del 2026-08-01 19-51-59" src="https://github.com/user-attachments/assets/a1cc4981-5302-4e05-97a1-b15384b6489d" />


  ## Type

  - [ ] Bug fix
  - [ ] Feature
  - [x] UI/UX polish
  - [ ] Documentation
  - [ ] Build/release
  - [ ] Refactor
  - [ ] Security/privacy

  ## Verification

  - [x] `cd frontend && npm run build`
  - [x] `go test ./...`
  - [x] Manual smoke test performed
  - [ ] Not applicable

  Manual test notes:

  - Opened Settings in the test build.
  - Verified the responsive layout and expanded content area.
  - Verified dropdown labels and native arrows remain readable.
  - Verified narrow layouts stack labels and controls correctly.

  ## Risk

  - [x] Low: isolated change
  - [ ] Medium: shared UI/state/build behavior
  - [ ] High: storage, workspace format, security, release pipeline, or network behavior

  ## Checklist

  - [x] The change preserves local-first behavior.
  - [x] User-facing behavior is documented.
  - [x] Screenshots are included for visible UI changes.
  - [ ] `CHANGELOG.md` is updated under `[Unreleased]` if release-worthy.
  - [x] Secrets, tokens, cookies, and private URLs are not included in logs/screenshots.
